### PR TITLE
Validate url on config

### DIFF
--- a/python/neuromation/cli/rc.py
+++ b/python/neuromation/cli/rc.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import Dict, Optional
 
 import yaml
-import yarl
 from jose import JWTError, jwt
 from yarl import URL
 
@@ -50,7 +49,7 @@ class ConfigFactory:
         if url != "" and url[-1] == "/":
             raise ValueError("URL should not finish with trailing / symbol.")
 
-        parsed_url = yarl.URL(url)
+        parsed_url = URL(url)
 
         if parsed_url.scheme not in ["http", "https"]:
             raise ValueError("Valid scheme options are http and https.")

--- a/python/tests/cli/test_rc.py
+++ b/python/tests/cli/test_rc.py
@@ -31,61 +31,47 @@ class TestFactoryMethods:
 
         monkeypatch.setattr(Path, "home", home)
 
-    def test_factory(self, monkeypatch, nmrc):
-        self.patch_home_for_test(monkeypatch, nmrc)
-
+    def test_factory(self, patch_home_for_test):
         config: Config = Config(url="http://abc.def", auth="token1")
         rc.ConfigFactory._update_config(url="http://abc.def", auth="token1")
         config2: Config = rc.ConfigFactory.load()
         assert config == config2
 
-    def test_factory_update_url(self, monkeypatch, nmrc):
-        self.patch_home_for_test(monkeypatch, nmrc)
-
+    def test_factory_update_url(self, patch_home_for_test):
         config: Config = Config(url="http://abc.def", auth="token1")
         rc.ConfigFactory.update_api_url(url="http://abc.def")
         config2: Config = rc.ConfigFactory.load()
         assert config.url == config2.url
 
-    def test_factory_update_url_malformed(self, monkeypatch, nmrc):
-        self.patch_home_for_test(monkeypatch, nmrc)
-
+    def test_factory_update_url_malformed(self, patch_home_for_test):
         config: Config = Config(url="http://abc.def", auth="token1")
         with pytest.raises(ValueError):
             rc.ConfigFactory.update_api_url(url="ftp://abc.def")
         config2: Config = rc.ConfigFactory.load()
         assert config.url != config2.url
 
-    def test_factory_update_url_malformed_trailing_slash(self, monkeypatch, nmrc):
-        self.patch_home_for_test(monkeypatch, nmrc)
-
+    def test_factory_update_url_malformed_trailing_slash(self, patch_home_for_test):
         config: Config = Config(url="http://abc.def", auth="token1")
         with pytest.raises(ValueError):
             rc.ConfigFactory.update_api_url(url="http://abc.def/")
         config2: Config = rc.ConfigFactory.load()
         assert config.url != config2.url
 
-    def test_factory_update_url_malformed_with_fragment(self, monkeypatch, nmrc):
-        self.patch_home_for_test(monkeypatch, nmrc)
-
+    def test_factory_update_url_malformed_with_fragment(self, patch_home_for_test):
         config: Config = Config(url="http://abc.def", auth="token1")
         with pytest.raises(ValueError):
             rc.ConfigFactory.update_api_url(url="http://abc.def?blabla")
         config2: Config = rc.ConfigFactory.load()
         assert config.url != config2.url
 
-    def test_factory_update_url_malformed_with_anchor(self, monkeypatch, nmrc):
-        self.patch_home_for_test(monkeypatch, nmrc)
-
+    def test_factory_update_url_malformed_with_anchor(self, patch_home_for_test):
         config: Config = Config(url="http://abc.def", auth="token1")
         with pytest.raises(ValueError):
             rc.ConfigFactory.update_api_url(url="http://abc.def#ping")
         config2: Config = rc.ConfigFactory.load()
         assert config.url != config2.url
 
-    def test_factory_update_id_rsa(self, monkeypatch, nmrc):
-        self.patch_home_for_test(monkeypatch, nmrc)
-
+    def test_factory_update_id_rsa(self, patch_home_for_test):
         config: Config = Config(
             url=DEFAULTS.url, auth=DEFAULTS.auth, github_rsa_path="~/.ssh/id_rsa"
         )
@@ -93,15 +79,11 @@ class TestFactoryMethods:
         config2: Config = rc.ConfigFactory.load()
         assert config == config2
 
-    def test_factory_update_token_invalid(self, monkeypatch, nmrc):
-        self.patch_home_for_test(monkeypatch, nmrc)
-
+    def test_factory_update_token_invalid(self, patch_home_for_test):
         with pytest.raises(ValueError):
             rc.ConfigFactory.update_auth_token(token="not-a-token")
 
-    def test_factory_update_token_no_identity(self, monkeypatch, nmrc):
-        self.patch_home_for_test(monkeypatch, nmrc)
-
+    def test_factory_update_token_no_identity(self, patch_home_for_test):
         jwt_hdr = """eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"""
         jwt_claims = """eyJub3QtaWRlbnRpdHkiOiJub3QtaWRlbnRpdHkifQ"""
         jwt_sig = """ag9NbxxOvp2ufMCUXk2pU3MMf2zYftXHQdOZDJajlvE"""


### PR DESCRIPTION
Closes https://github.com/neuromation/platform-api-clients/issues/67
As we do not enforce expiration field now on the JWT token, please consider having a different github issue to address it.