### PR TITLE
Add isort validation to Makefile

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -34,10 +34,6 @@ test-all:
 		--cov-report xml:coverage.xml \
 		tests
 
-.PHONY: isort
-isort:
-	isort -rc neuromation tests
-
 .PHONY: lint
 lint:
 	isort -c -rc neuromation tests
@@ -53,13 +49,10 @@ publish:
 coverage:
 	$(SHELL) <(curl -s https://codecov.io/bash) -X coveragepy
 
-.PHONY: black
-black:
-	black neuromation tests
-
 .PHONY: format
-format: isort black
-
+format:
+	isort -rc neuromation tests
+	black neuromation tests
 
 # TODO (artyom, 07/16/2018): swap e2e and test once coverage output
 # of both is combined. Otherwise e2e will override unit tests with


### PR DESCRIPTION
We use _isort_ and _black_ for code formatting. But only _black_ validated during build.
In this commit I have added validation for _isort_ too