### PR TITLE
Change defaults for job resources

### DIFF
--- a/python/neuromation/cli/main.py
+++ b/python/neuromation/cli/main.py
@@ -498,11 +498,11 @@ Commands:
             Options:
                 -g, --gpu NUMBER          Number of GPUs to request [default: 0]
                 --gpu-model MODEL         GPU to use [default: nvidia-tesla-k80]
-                -x, --extshm              Request extended '/dev/shm' space
                                           Available options:
                                               nvidia-tesla-k80
                                               nvidia-tesla-p4
                                               nvidia-tesla-v100
+                -x, --extshm              Request extended '/dev/shm' space
                 -c, --cpu NUMBER          Number of CPUs to request [default: 0.1]
                 -m, --memory AMOUNT       Memory amount to request [default: 1G]
                 --http NUMBER             Enable HTTP port forwarding to container


### PR DESCRIPTION
Discussion: https://neuromation.slack.com/archives/C9Z1UBC6A/p1543339148233500 and following pollings

Memory defaults: 1G
CPU defaults: 0.1
GPU default: 0

TODO: `--preemptible`=true and `--extshm`=true by default (these options are boolean and parameterless, so we need to invert them to `--non-preemptible` )