### PR TITLE
Memoize Config.docker_registry_url value

### DIFF
--- a/python/neuromation/cli/main.py
+++ b/python/neuromation/cli/main.py
@@ -735,7 +735,7 @@ storage:/data/2018q1:/data:ro --ssh 22 pytorch:latest
 
         def _get_image_platform_full_name(image_name):
             config = rc.ConfigFactory.load()
-            registry_url = config.docker_registry_url()
+            registry_url = config.registry_hostname
             user_name = config.get_platform_user_name()
             target_image_name = f"{registry_url}/{user_name}/{image_name}"
             return target_image_name
@@ -750,7 +750,7 @@ storage:/data/2018q1:/data:ro --ssh 22 pytorch:latest
             """
             config = rc.ConfigFactory.load()
             platform_user_name = config.get_platform_user_name()
-            registry_url = config.docker_registry_url()
+            registry_url = config.registry_hostname
             return DockerHandler(platform_user_name, config.auth).push(
                 registry_url, image_name
             )
@@ -765,7 +765,7 @@ storage:/data/2018q1:/data:ro --ssh 22 pytorch:latest
             """
             config = rc.ConfigFactory.load()
             platform_user_name = config.get_platform_user_name()
-            registry_url = config.docker_registry_url()
+            registry_url = config.registry_hostname
             return DockerHandler(platform_user_name, config.auth).pull(
                 registry_url, image_name
             )

--- a/python/neuromation/cli/rc.py
+++ b/python/neuromation/cli/rc.py
@@ -14,10 +14,9 @@ class Config:
     auth: str = None
     github_rsa_path: str = ""
 
-    def docker_registry_url(self) -> str:
-        platform_url = URL(self.url)
-        docker_registry_url = platform_url.host.replace("platform.", "registry.")
-        return docker_registry_url
+    def __post_init__(self):
+        platform_host = URL(self.url).host
+        self.registry_hostname = platform_host.replace("platform.", "registry.")
 
     def get_platform_user_name(self) -> Optional[str]:
         if self.auth != "" and self.auth is not None:


### PR DESCRIPTION
Necessary for PR https://github.com/neuromation/platform-api-clients/pull/321
Memoizes the hostname of registry api service in Config + fixes inconsistency with this field name (it was called `docker_registry_url` though in fact it's `docker_registry_hostname`)