### PR TITLE
Drop TestRetriesExceeded exception

### DIFF
--- a/python/tests/e2e/conftest.py
+++ b/python/tests/e2e/conftest.py
@@ -133,9 +133,7 @@ def run(monkeypatch, capfd, tmp_path):
 
             return SysCap(out.strip(), err.strip())
         else:
-            raise RuntimeError(
-                f"Retries exceeded during 'neuro {' '.join(arguments)}'"
-            )
+            raise RuntimeError(f"Retries exceeded during 'neuro {' '.join(arguments)}'")
 
     yield _run
     # try to kill all executed jobs regardless of the status


### PR DESCRIPTION
Use `RuntimeError` instead.
There are two problems with the exception:
1. It starts with `Test`. `pytest` assumes that the class started with `Test` is a test suite. The class is analyzed on auto-discover, instantiated etc.  `RetriesExceeded` is much better name.
2. No code expects the class instance, e.g. there is no `except TestRepriesExceeded`. Basically, it means that the specific exception class is not needed; `RuntimeError` can serve the purpose pretty well.