### PR TITLE
Allow to use local account when running e2e tests

### DIFF
--- a/python/tests/e2e/conftest.py
+++ b/python/tests/e2e/conftest.py
@@ -63,6 +63,10 @@ class Helper:
             self._tmpstorage = None
 
     @property
+    def config(self):
+        return self._config
+
+    @property
     def tmpstorage(self):
         return self._tmpstorage
 
@@ -271,15 +275,18 @@ class Helper:
 def config(tmp_path, monkeypatch):
     e2e_test_token = os.environ.get("CLIENT_TEST_E2E_USER_NAME")
 
-    rc_text = RC_TEXT.format(token=e2e_test_token)
-    config_path = tmp_path / ".nmrc"
-    config_path.write_text(rc_text)
-    config_path.chmod(0o600)
+    if e2e_test_token:
+        # Make a config on CI
+        # use default user config for local testing
+        rc_text = RC_TEXT.format(token=e2e_test_token)
+        config_path = tmp_path / ".nmrc"
+        config_path.write_text(rc_text)
+        config_path.chmod(0o600)
 
-    def _home():
-        return Path(tmp_path)
+        def _home():
+            return Path(tmp_path)
 
-    monkeypatch.setattr(Path, "home", _home)
+        monkeypatch.setattr(Path, "home", _home)
 
     config = rc.ConfigFactory.load()
     yield config

--- a/python/tests/e2e/test_e2e_images.py
+++ b/python/tests/e2e/test_e2e_images.py
@@ -5,7 +5,6 @@ import aiodocker
 import pytest
 from yarl import URL
 
-from neuromation.cli.rc import ConfigFactory
 from neuromation.client import JobStatus
 from tests.e2e.utils import attempt
 
@@ -76,7 +75,7 @@ def test_images_complete_lifecycle(helper, run_cli, image, tag, loop, docker):
     loop.run_until_complete(docker.images.delete(pulled_image, force=True))
 
     # Execute image and check result
-    config = ConfigFactory.load()
+    config = helper.config
     registry_url = URL(config.registry_url)
     path = image_url.path
     image_with_repo = f'{registry_url.host}/{image_url.host}/{path.lstrip("/")}'


### PR DESCRIPTION
Setting up `CLIENT_TEST_E2E_USER_NAME` env var is tedious, I constantly miss the token value.
Using a local config previously initialized by `neuro login` is much easier.