### PR TITLE
Fix e2e tests cleanup

### DIFF
--- a/python/tests/e2e/conftest.py
+++ b/python/tests/e2e/conftest.py
@@ -376,7 +376,10 @@ def run_cli(capfd, config):
             post_out, post_err = capfd.readouterr()
             out = post_out[pre_out_size:]
             err = post_err[pre_err_size:]
-            if arguments[0:2] in (["job", "submit"], ["model", "train"]):
+            if any(
+                " ".join(arguments).startswith(start)
+                for start in ("submit", "job submit", "model train")
+            ):
                 match = job_id_pattern.search(out)
                 if match:
                     executed_jobs_list.append(match.group(1))

--- a/python/tests/e2e/test_e2e_images.py
+++ b/python/tests/e2e/test_e2e_images.py
@@ -81,7 +81,6 @@ def test_images_complete_lifecycle(helper, run_cli, image, tag, loop, docker):
     image_with_repo = f'{registry_url.host}/{image_url.host}/{path.lstrip("/")}'
     captured = run_cli(
         [
-            "job",
             "submit",
             image_with_repo,
             "--memory",


### PR DESCRIPTION
Kill also jobs run by e2e tests via `neuro submit ...` shortcut.