### PR TITLE
Add timeouts to CI

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -94,7 +94,7 @@ _e2e:
 .PHONY: _e2e_win
 _e2e_win:
 	pytest \
-		-m "e2e and not no_win32" --timeout=570 \
+		-m "e2e and not no_win32" \
 		--cov=neuromation \
 		--cov-report term-missing:skip-covered \
 		--cov-report xml:coverage.xml \


### PR DESCRIPTION
Today there too many tests which CircleCI job killed by internal timeout, i.e. https://circleci.com/gh/neuromation/platform-api-clients/2642

Let's try to add timeout to e2e tests for CI too.
Then failed job will be like as https://circleci.com/gh/neuromation/platform-api-clients/2647
It is a little bit better but still miss information which test cause problem.