### PR TITLE
Fix volume mounts on Windows

### DIFF
--- a/python/neuromation/client/jobs.py
+++ b/python/neuromation/client/jobs.py
@@ -148,7 +148,7 @@ class Volume:
         pso = PlatformStorageOperation(username)
         pso._is_storage_path_url(urlparse(storage_path, scheme="file"))
         storage_path_with_principal = (
-            f"storage:/{str(pso.render_uri_path_with_principal(storage_path))}"
+            f"{str(storage_path).replace('~', username)}"
         )
 
         return Volume(storage_path_with_principal, container_path, read_only)


### PR DESCRIPTION
In remote volume mounts don't apply local system transformations to the URIs.

Note: I understand this might break the tests, I am opening this PR to see the results on AppVeyor.