### PR TITLE
Use gmktemp instead of mktemp for MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ FLAKE8_REGEXP := .+\\.py$
 
 DEPS_REGEXP := ^(requirements/.+|setup.py+)
 
+README_PATTERN := README.XXXXXXXX.md
+
 .PHONY: help
 .SILENT: help
 help:
@@ -212,7 +214,7 @@ docs:
 
 
 .PHONY: lint-docs
-lint-docs: TMP:=$(shell mktemp $${TMPDIR:-/tmp}/README.XXXXXXXX.md)
+lint-docs: TMP:=$(shell if command -v gmktemp >/dev/null 2>&1 ; then gmktemp $${TMPDIR:-/tmp}/${README_PATTERN} ; else mktemp $${TMPDIR:-/tmp}/${README_PATTERN} ; fi)
 lint-docs:
 	build-tools/cli-help-generator.py README.in.md ${TMP}
 	markdown-toc -t github -h 6 ${TMP}


### PR DESCRIPTION
`mktemp` in Mac OS is a BSD version and has slightly different behavior compared to Unix `mktemp`. Specifically, `XXXXXXX` in `mktemp /tmp/README.XXXXXX.md` is interpreted literally and it always results in the same file being created (`/tmp/README.XXXXXX.md`) causing every make task to fail until the file is manually deleted.

There's `gmktemp` util which is a GNU version and behaves just like `mktemp` on Unix.

The change in the Makefile checks whether `gmktemp` is available and uses it instead of `mktemp`.