### PR TITLE
Fix flake8 invokation in case of venv in the source dir.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,14 @@ BRANCH := $(shell git branch | grep \* | cut -d ' ' -f2)
 
 MYPY_CACHE_DIR=.mypy_cache/$(shell md5sum setup.py | awk '{print $$1}')-$(shell find requirements -type f -exec md5sum {} \; | sort -k 2 | md5sum | awk '{print $$1}')
 
-ISORT_DIRS := neuromation tests build-tools
-ISORT_REGEXP := ^(neuromation|tests|build-tools)/.+\\.py
+ISORT_DIRS := neuromation tests build-tools setup.py
+ISORT_REGEXP := ^((neuromation|tests|build-tools)/.+|setup)\\.py$
 BLACK_DIRS := $(ISORT_DIRS)
 BLACK_REGEXP := $(ISORT_REGEXP)
 MYPY_DIRS :=  neuromation
-MYPY_REGEXP := ^neuromation/.+\\.py
-FLAKE8_DIRS := .
-FLAKE8_REGEXP := .+\\.py$
+MYPY_REGEXP := ^neuromation/.+\\.py$
+FLAKE8_DIRS := $(ISORT_DIRS)
+FLAKE8_REGEXP := $(ISORT_REGEXP)
 
 DEPS_REGEXP := ^(requirements/.+|setup.py+)
 

--- a/setup.py
+++ b/setup.py
@@ -45,13 +45,15 @@ setup(
     long_description_content_type="text/markdown; charset=UTF-8; variant=GFM",
     author="Neuromation Team",
     author_email="pypi@neuromation.io",  # TODO: change this email
-    license='Apache License, version 2.0',
+    license="Apache License, version 2.0",
     url="https://neuromation.io/",
     packages=find_packages(include=("neuromation", "neuromation.*")),
-    entry_points={"console_scripts": [
-        "neuro=neuromation.cli:main",
-        "docker-credential-neuro=neuromation.cli:dch"
-    ]},
+    entry_points={
+        "console_scripts": [
+            "neuro=neuromation.cli:main",
+            "docker-credential-neuro=neuromation.cli:dch",
+        ]
+    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: Other/Proprietary License",
@@ -64,6 +66,6 @@ setup(
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
         "Topic :: Software Development",
         "Topic :: Utilities",
-        'License :: OSI Approved :: Apache Software License',
+        "License :: OSI Approved :: Apache Software License",
     ],
 )


### PR DESCRIPTION
Specify explicit directories to flake8 to avoid scanning the venv directory.
Also include setup.py in linters checks.

Currently `make lint` fails if `venv` is created in the current directory.