### PR TITLE
Patch client: too long DNS label for named jobs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
-from typing import Callable
+import uuid
+from typing import Callable, Iterator
 
 import pytest
 from jose import jwt
@@ -60,3 +61,11 @@ def make_client(token: str, auth_config: _AuthConfig) -> Callable[..., Client]:
         return Client._create(config)
 
     return go
+
+
+@pytest.fixture()
+def random_job_name() -> Iterator[Callable[[], str]]:
+    def _impl() -> str:
+        return f"job-{str(uuid.uuid1())[:8]}"
+
+    yield _impl

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -1,7 +1,6 @@
 import re
 from pathlib import Path
-from typing import List, Optional, Tuple
-from uuid import uuid4
+from typing import Callable, List, Optional, Tuple
 
 import pytest
 
@@ -49,7 +48,7 @@ def test_empty_directory_ls_output(helper: Helper) -> None:
 
 
 @pytest.mark.e2e
-def test_e2e_job_top(helper: Helper) -> None:
+def test_e2e_job_top(helper: Helper, random_job_name: Callable[[], str]) -> None:
     def split_non_empty_parts(line: str, separator: Optional[str] = None) -> List[str]:
         return [part.strip() for part in line.split(separator) if part.strip()]
 
@@ -58,7 +57,7 @@ def test_e2e_job_top(helper: Helper) -> None:
         "do sleep 1; let COUNTER+=1; done; sleep 30"
     )
     command = f"bash -c '{bash_script}'"
-    job_name = f"test-job-{str(uuid4())[:8]}"
+    job_name = random_job_name()
     aux_params = ["--volume", f"{helper.tmpstorage}:/data:ro", "--name", job_name]
 
     helper.run_job_and_wait_state(

--- a/tests/e2e/test_e2e_jobs.py
+++ b/tests/e2e/test_e2e_jobs.py
@@ -4,7 +4,6 @@ import re
 from pathlib import Path
 from time import sleep, time
 from typing import Any, AsyncIterator, Callable, Dict, Iterator
-from uuid import uuid4
 
 import aiohttp
 import pytest
@@ -394,8 +393,8 @@ def test_e2e_multiple_env_from_file(helper: Helper, tmp_path: Path) -> None:
 
 
 @pytest.mark.e2e
-def test_e2e_ssh_exec_true(helper: Helper) -> None:
-    job_name = f"test-job-{str(uuid4())[:8]}"
+def test_e2e_ssh_exec_true(helper: Helper, random_job_name: Callable[[], str]) -> None:
+    job_name = random_job_name()
     command = 'bash -c "sleep 15m; false"'
     captured = helper.run_cli(
         [


### PR DESCRIPTION
Temporary patch for the problem https://github.com/neuromation/platform-client-python/issues/750: 
Some jobs have too long DNS labels for `http_url_named` so that `yarl.URL` fails to encode such URLs. Since we assume that all values of `http_url_named` are strictly in the form `https://{job_name}-{job_owner}.jobs.neu.ro`, we can skip encoding of such URLs by applying `encoded=True` to `yarl.URL` constructor.

*Changes*:
1. `http_url_named` is parsed with `URL(..., encoded=True)`
2. e2e tests produce shorter job names (of length 12, see `random_job_name()`)