### PR TITLE
Fix test_normalize_local_path_uri__tilde_in_absolute_path on Windows.

### DIFF
--- a/tests/api/test_url_utils.py
+++ b/tests/api/test_url_utils.py
@@ -204,7 +204,7 @@ async def test_normalize_local_path_uri__tilde_in_absolute_path(
     url = normalize_local_path_uri(url)
     assert url.scheme == "file"
     assert url.host is None
-    assert url.path == (Path.cwd() / "/~/path/to/file.txt").as_posix()
+    assert _extract_path(url) == Path.cwd() / "/~/path/to/file.txt"
     assert str(url) == (Path.cwd() / "/~/path/to/file.txt").as_uri().replace("%7E", "~")
 
 


### PR DESCRIPTION
Fixes the test changed in  #769.