### PR TITLE
Expand tilde in acl commands.

### DIFF
--- a/neuromation/api/users.py
+++ b/neuromation/api/users.py
@@ -25,10 +25,6 @@ class Permission:
     uri: URL
     action: Action
 
-    @classmethod
-    def from_cli(cls, username: str, uri: URL, action: Action) -> "Permission":
-        return Permission(uri=uri_from_cli(username, uri), action=action)
-
     def to_api(self) -> Dict[str, Any]:
         primitive: Dict[str, Any] = {"uri": str(self.uri), "action": self.action.value}
         return primitive
@@ -103,18 +99,3 @@ def get_token_username(token: str) -> str:
         if identity_claim in claims:
             return claims[identity_claim]
     raise ValueError("JWT Claims structure is not correct.")
-
-
-def uri_from_cli(username: str, uri: URL) -> URL:
-    if not uri.scheme:
-        raise ValueError(
-            "URI Scheme not specified. " "Please specify one of storage, image, job."
-        )
-    if uri.scheme not in ["storage", "image", "job"]:
-        raise ValueError(
-            f"Unsupported URI scheme: {uri.scheme or 'Empty'}. "
-            f"Please specify one of storage, image, job."
-        )
-    if not uri.host:
-        uri = URL(f"{uri.scheme}://{username}/") / uri.path.lstrip("/")
-    return uri

--- a/neuromation/cli/share.py
+++ b/neuromation/cli/share.py
@@ -4,7 +4,6 @@ from typing import Any, Optional
 import click
 
 from neuromation.api import Permission, SharedPermission
-from neuromation.api.users import uri_from_cli
 
 from .root import Root
 from .utils import (
@@ -43,9 +42,7 @@ async def grant(root: Root, uri: str, user: str, permission: str) -> None:
     try:
         uri_obj = parse_resource_for_sharing(uri, root)
         action_obj = parse_permission_action(permission)
-        permission_obj = Permission.from_cli(
-            username=root.username, uri=uri_obj, action=action_obj
-        )
+        permission_obj = Permission(uri=uri_obj, action=action_obj)
         log.info(f"Using resource '{permission_obj.uri}'")
 
         await root.client.users.share(user, permission_obj)
@@ -69,7 +66,6 @@ async def revoke(root: Root, uri: str, user: str) -> None:
     """
     try:
         uri_obj = parse_resource_for_sharing(uri, root)
-        uri_obj = uri_from_cli(username=root.username, uri=uri_obj)
         log.info(f"Using resource '{uri_obj}'")
 
         await root.client.users.revoke(user, uri_obj)

--- a/neuromation/cli/storage.py
+++ b/neuromation/cli/storage.py
@@ -3,8 +3,6 @@ from typing import List
 
 import click
 
-from neuromation.api.url_utils import uri_from_cli
-
 from .command_progress_report import ProgressBase
 from .formatters import (
     BaseFilesFormatter,
@@ -14,7 +12,7 @@ from .formatters import (
     VerticalColumnsFilesFormatter,
 )
 from .root import Root
-from .utils import async_cmd, command, group
+from .utils import async_cmd, command, group, parse_file_resource
 
 
 log = logging.getLogger(__name__)
@@ -48,7 +46,7 @@ async def rm(root: Root, paths: List[str], recursive: bool) -> None:
     neuro rm --recursive storage://{username}/foo/
     """
     for path in paths:
-        uri = uri_from_cli(path, root.username)
+        uri = parse_file_resource(path, root)
         log.info(f"Using path '{uri}'")
 
         await root.client.storage.rm(uri, recursive=recursive)
@@ -93,7 +91,7 @@ async def ls(
             else:
                 formatter = SimpleFilesFormatter(root.color)
 
-        uri = uri_from_cli(path, root.username)
+        uri = parse_file_resource(path, root)
         log.info(f"Using path '{uri}'")
 
         files = await root.client.storage.ls(uri)
@@ -129,11 +127,11 @@ async def cp(
     # explicit file:// scheme set
     neuro cp storage:///foo file:///foo
     """
-    dst = uri_from_cli(destination, root.username)
+    dst = parse_file_resource(destination, root)
     log.info(f"Using destination path: '{dst}'")
 
     for source in sources:
-        src = uri_from_cli(source, root.username)
+        src = parse_file_resource(source, root)
 
         progress_obj = ProgressBase.create_progress(progress)
 
@@ -172,7 +170,7 @@ async def mkdir(root: Root, paths: List[str], parents: bool) -> None:
     """
 
     for path in paths:
-        uri = uri_from_cli(path, root.username)
+        uri = parse_file_resource(path, root)
         log.info(f"Using path '{uri}'")
 
         await root.client.storage.mkdirs(uri, parents=parents, exist_ok=parents)
@@ -202,10 +200,10 @@ async def mv(root: Root, sources: List[str], destination: str) -> None:
     neuro mv storage://{username}/foo/ storage://{username}/bar/baz/foo/
     """
 
-    dst = uri_from_cli(destination, root.username)
+    dst = parse_file_resource(destination, root)
     log.info(f"Using destination path: '{dst}'")
     for source in sources:
-        src = uri_from_cli(source, root.username)
+        src = parse_file_resource(source, root)
         log.info(f"Using source path:      '{src}'")
 
         await root.client.storage.mv(src, dst)

--- a/neuromation/cli/utils.py
+++ b/neuromation/cli/utils.py
@@ -32,6 +32,7 @@ from neuromation.api import (
     JobDescription,
     Volume,
 )
+from neuromation.api.url_utils import uri_from_cli
 from neuromation.strings.parse import to_megabytes
 from neuromation.utils import run
 
@@ -363,6 +364,9 @@ async def resolve_job(client: Client, id_or_name: str) -> str:
     return job_id
 
 
+SHARE_SCHEMES = ("storage", "image", "job")
+
+
 def parse_resource_for_sharing(uri: str, root: Root) -> URL:
     """ Parses the neuromation resource URI string.
     Available schemes: storage, image, job. For image URIs, tags are not allowed.
@@ -371,7 +375,15 @@ def parse_resource_for_sharing(uri: str, root: Root) -> URL:
         parser = ImageNameParser(root.username, root.registry_url)
         image = parser.parse_as_neuro_image(uri, allow_tag=False)
         uri = image.as_url_str()
-    return URL(uri)
+
+    return uri_from_cli(uri, root.username, allowed_schemes=("storage", "image", "job"))
+
+
+def parse_file_resource(uri: str, root: Root) -> URL:
+    """ Parses the neuromation resource URI string.
+    Available schemes: file, storage.
+    """
+    return uri_from_cli(uri, root.username, allowed_schemes=("file", "storage"))
 
 
 def parse_permission_action(action: str) -> Action:

--- a/tests/api/test_users.py
+++ b/tests/api/test_users.py
@@ -45,21 +45,6 @@ async def mocked_revoke_client(
 
 
 class TestUsersShare:
-    def test_permissions_from_cli(self) -> None:
-        with pytest.raises(ValueError, match=r"URI Scheme not specified"):
-            Permission.from_cli("bob", URL("scheme-less/resource"), Action.MANAGE)
-
-        with pytest.raises(ValueError, match=r"Unsupported URI scheme"):
-            Permission.from_cli("bob", URL("http://neuromation.io"), Action.READ)
-
-        user_less_permission = Permission.from_cli(
-            "bob", URL("storage:resource"), Action.MANAGE
-        )
-        full_permission = Permission.from_cli(
-            "bob", URL("storage://bob/resource"), Action.MANAGE
-        )
-        assert user_less_permission == full_permission
-
     async def test_share_unknown_user(self, mocked_share_client: Client) -> None:
         with pytest.raises(ResourceNotFound):
             await mocked_share_client.users.share(


### PR DESCRIPTION
Use the same code for parsing URI in "storage" and "acl" subcommands.

Closes #801.