### PR TITLE
Set errno and filename for manually raised OSError.

### DIFF
--- a/neuromation/api/storage.py
+++ b/neuromation/api/storage.py
@@ -87,7 +87,7 @@ class Storage(metaclass=NoPublicConstructor):
             except ResourceNotFound:
                 pass
             else:
-                raise FileExistsError(errno.EEXIST, "File exists:", str(uri))
+                raise FileExistsError(errno.EEXIST, "File exists", str(uri))
 
         if not parents:
             parent = uri
@@ -99,7 +99,7 @@ class Storage(metaclass=NoPublicConstructor):
                     await self.stats(parent)
                 except ResourceNotFound:
                     raise FileNotFoundError(
-                        errno.ENOENT, "No such directory:", str(parent)
+                        errno.ENOENT, "No such directory", str(parent)
                     )
 
         url = self._config.cluster_config.storage_url / self._uri_to_path(uri)
@@ -195,11 +195,13 @@ class Storage(metaclass=NoPublicConstructor):
         dst = normalize_storage_path_uri(dst, self._config.auth_token.username)
         path = _extract_path(src)
         if not path.exists():
-            raise FileNotFoundError(f"'{path}' does not exist")
+            raise FileNotFoundError(errno.ENOENT, "No such file", str(path))
         if path.is_dir():
-            raise IsADirectoryError(f"'{path}' is a directory, use recursive copy")
+            raise IsADirectoryError(
+                errno.EISDIR, "Is a directory, use recursive copy", str(path)
+            )
         if not path.is_file():
-            raise OSError(f"'{path}' should be a regular file")
+            raise OSError(errno.EINVAL, "Not a regular file", str(path))
         if not dst.name:
             # file:src/file.txt -> storage:dst/ ==> storage:dst/file.txt
             dst = dst / src.name
@@ -214,9 +216,13 @@ class Storage(metaclass=NoPublicConstructor):
                 stats = await self.stats(dst.parent)
                 if not stats.is_dir():
                     # parent path should be a folder
-                    raise NotADirectoryError(dst.parent)
+                    raise NotADirectoryError(
+                        errno.ENOTDIR, "Not a directory", str(dst.parent)
+                    )
             except ResourceNotFound:
-                raise NotADirectoryError(dst.parent)
+                raise NotADirectoryError(
+                    errno.ENOTDIR, "Not a directory", str(dst.parent)
+                )
         await self.create(dst, self._iterate_file(path, progress=progress))
 
     async def upload_dir(
@@ -229,13 +235,13 @@ class Storage(metaclass=NoPublicConstructor):
         dst = normalize_storage_path_uri(dst, self._config.auth_token.username)
         path = _extract_path(src).resolve()
         if not path.exists():
-            raise FileNotFoundError(f"{path} does not exist")
+            raise FileNotFoundError(errno.ENOENT, "No such file", str(path))
         if not path.is_dir():
-            raise NotADirectoryError(f"{path} should be a directory")
+            raise NotADirectoryError(errno.ENOTDIR, "Not a directory", str(path))
         try:
             stat = await self.stats(dst)
             if not stat.is_dir():
-                raise NotADirectoryError(f"{dst} should be a directory")
+                raise NotADirectoryError(errno.ENOTDIR, "Not a directory", str(dst))
         except ResourceNotFound:
             await self.mkdirs(dst)
         for child in path.iterdir():
@@ -263,7 +269,7 @@ class Storage(metaclass=NoPublicConstructor):
             if path.is_dir():
                 path = path / src.name
             elif not path.is_file():
-                raise OSError(f"{path} should be a regular file")
+                raise OSError(errno.EINVAL, "Not a regular file", str(path))
         loop = asyncio.get_event_loop()
         with path.open("wb") as stream:
             stat = await self.stats(src)


### PR DESCRIPTION
The constructor of OSError and subclasses is complex. By default it does not set `errno`. You need to pass 3 arguments explicitly to set `errno` and `filename` attributes. They will be used to format the final string representation of the exception.