### PR TITLE
Fix client API to accept empty configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 	* [neuro config](#neuro-config)
 		* [neuro config login](#neuro-config-login)
 		* [neuro config login-with-token](#neuro-config-login-with-token)
+		* [neuro config login-headless](#neuro-config-login-headless)
 		* [neuro config show](#neuro-config-show)
 		* [neuro config show-token](#neuro-config-show-token)
 		* [neuro config docker](#neuro-config-docker)
@@ -192,7 +193,7 @@ neuro run pytorch:latest --volume=HOME
 
 Name | Description|
 |----|------------|
-|_\-s, --preset PRESET_|Predefined job profile  \[default: gpu-small]|
+|_\-s, --preset PRESET_|Predefined job profile|
 |_\-x, --extshm / -X, --no-extshm_|Request extended '/dev/shm' space  \[default: True]|
 |_--http INTEGER_|Enable HTTP port forwarding to container  \[default: 80]|
 |_\--http-auth / --no-http-auth_|Enable HTTP authentication for forwarded HTTP port  \[default: True]|
@@ -331,12 +332,31 @@ Name | Description|
 
 ### neuro job port-forward
 
-Forward port\(s) of a running job to local port\(s).
+Forward port\(s) of a running job to local port\(s).<br/>
 
 **Usage:**
 
 ```bash
-neuro job port-forward [OPTIONS] JOB [LOCAL_REMOTE_PORT]...
+neuro job port-forward [OPTIONS] JOB LOCAL_REMOTE_PORT...
+```
+
+**Examples:**
+
+```bash
+
+# Forward local port 2080 to port 80 of job's container.
+# You can use http://localhost:2080 in browser to access job's served http
+neuro job port-forward my-fastai-job 2080:80
+
+# Forward local port 2222 to job's port 22
+# Then copy all data from container's folder '/data' to current folder
+# (please run second command in other terminal)
+neuro job port-forward my-job-with-ssh-server 2222:22
+rsync -avxzhe ssh -p 2222 root@localhost:/data .
+
+# Forward few ports at once
+neuro job port-forward my-job- 2080:80 2222:22 2000:100
+
 ```
 
 **Options:**
@@ -443,7 +463,7 @@ Copy files and directories.<br/><br/>Either SOURCES or DESTINATION should have s
 **Usage:**
 
 ```bash
-neuro storage cp [OPTIONS] SOURCE DESTINATION
+neuro storage cp [OPTIONS] SOURCES... DESTINATION
 ```
 
 **Examples:**
@@ -478,7 +498,7 @@ List directory contents.<br/><br/>By default PATH is equal user`s home dir \(sto
 **Usage:**
 
 ```bash
-neuro storage ls [OPTIONS] [PATH]
+neuro storage ls [OPTIONS] [PATHS]...
 ```
 
 **Options:**
@@ -500,16 +520,17 @@ Remove files or directories.<br/>
 **Usage:**
 
 ```bash
-neuro storage rm [OPTIONS] PATH
+neuro storage rm [OPTIONS] PATHS...
 ```
 
 **Examples:**
 
 ```bash
 
-neuro rm storage:///foo/bar/
-neuro rm storage:/foo/bar/
-neuro rm storage://{username}/foo/bar/
+neuro rm storage:///foo/bar
+neuro rm storage:/foo/bar
+neuro rm storage://{username}/foo/bar
+neuro rm --recursive storage://{username}/foo/
 
 ```
 
@@ -517,6 +538,7 @@ neuro rm storage://{username}/foo/bar/
 
 Name | Description|
 |----|------------|
+|_\-r, --recursive_|remove directories and their contents recursively|
 |_--help_|Show this message and exit.|
 
 
@@ -529,13 +551,14 @@ Make directories.
 **Usage:**
 
 ```bash
-neuro storage mkdir [OPTIONS] PATH
+neuro storage mkdir [OPTIONS] PATHS...
 ```
 
 **Options:**
 
 Name | Description|
 |----|------------|
+|_\-p, --parents_|No error if existing, make parent directories as needed|
 |_--help_|Show this message and exit.|
 
 
@@ -548,7 +571,7 @@ Move or rename files and directories.<br/><br/>SOURCE must contain path to the f
 **Usage:**
 
 ```bash
-neuro storage mv [OPTIONS] SOURCE DESTINATION
+neuro storage mv [OPTIONS] SOURCES... DESTINATION
 ```
 
 **Examples:**
@@ -704,6 +727,7 @@ Name | Description|
 |---|---|
 | _[neuro config login](#neuro-config-login)_| Log into Neuromation Platform |
 | _[neuro config login\-with-token](#neuro-config-login-with-token)_| Log into Neuromation Platform with token |
+| _[neuro config login-headless](#neuro-config-login-headless)_| Log into Neuromation Platform from non-GUI server environment |
 | _[neuro config show](#neuro-config-show)_| Print current settings |
 | _[neuro config show-token](#neuro-config-show-token)_| Print current authorization token |
 | _[neuro config docker](#neuro-config-docker)_| Configure docker client for working with platform registry |
@@ -739,6 +763,25 @@ Log into Neuromation Platform with token.<br/><br/>TOKEN is authentication token
 
 ```bash
 neuro config login-with-token [OPTIONS] TOKEN [URL]
+```
+
+**Options:**
+
+Name | Description|
+|----|------------|
+|_--help_|Show this message and exit.|
+
+
+
+
+### neuro config login-headless
+
+Log into Neuromation Platform from non-GUI server environment.<br/><br/>URL is a platform entrypoint URL.<br/><br/>The command works similar to "neuro login" but instead of opening a browser<br/>for performing OAuth registration prints an URL that should be open on guest<br/>host.<br/><br/>Then user inputs a code displayed in a browser after successful login back<br/>in neuro command to finish the login process.
+
+**Usage:**
+
+```bash
+neuro config login-headless [OPTIONS] [URL]
 ```
 
 **Options:**
@@ -1054,7 +1097,7 @@ neuro run pytorch:latest --volume=HOME
 
 Name | Description|
 |----|------------|
-|_\-s, --preset PRESET_|Predefined job profile  \[default: gpu-small]|
+|_\-s, --preset PRESET_|Predefined job profile|
 |_\-x, --extshm / -X, --no-extshm_|Request extended '/dev/shm' space  \[default: True]|
 |_--http INTEGER_|Enable HTTP port forwarding to container  \[default: 80]|
 |_\--http-auth / --no-http-auth_|Enable HTTP authentication for forwarded HTTP port  \[default: True]|
@@ -1193,12 +1236,31 @@ Name | Description|
 
 ## neuro port-forward
 
-Forward port\(s) of a running job to local port\(s).
+Forward port\(s) of a running job to local port\(s).<br/>
 
 **Usage:**
 
 ```bash
-neuro port-forward [OPTIONS] JOB [LOCAL_REMOTE_PORT]...
+neuro port-forward [OPTIONS] JOB LOCAL_REMOTE_PORT...
+```
+
+**Examples:**
+
+```bash
+
+# Forward local port 2080 to port 80 of job's container.
+# You can use http://localhost:2080 in browser to access job's served http
+neuro job port-forward my-fastai-job 2080:80
+
+# Forward local port 2222 to job's port 22
+# Then copy all data from container's folder '/data' to current folder
+# (please run second command in other terminal)
+neuro job port-forward my-job-with-ssh-server 2222:22
+rsync -avxzhe ssh -p 2222 root@localhost:/data .
+
+# Forward few ports at once
+neuro job port-forward my-job- 2080:80 2222:22 2000:100
+
 ```
 
 **Options:**
@@ -1313,7 +1375,7 @@ Copy files and directories.<br/><br/>Either SOURCES or DESTINATION should have s
 **Usage:**
 
 ```bash
-neuro cp [OPTIONS] SOURCE DESTINATION
+neuro cp [OPTIONS] SOURCES... DESTINATION
 ```
 
 **Examples:**
@@ -1348,7 +1410,7 @@ List directory contents.<br/><br/>By default PATH is equal user`s home dir \(sto
 **Usage:**
 
 ```bash
-neuro ls [OPTIONS] [PATH]
+neuro ls [OPTIONS] [PATHS]...
 ```
 
 **Options:**
@@ -1370,16 +1432,17 @@ Remove files or directories.<br/>
 **Usage:**
 
 ```bash
-neuro rm [OPTIONS] PATH
+neuro rm [OPTIONS] PATHS...
 ```
 
 **Examples:**
 
 ```bash
 
-neuro rm storage:///foo/bar/
-neuro rm storage:/foo/bar/
-neuro rm storage://{username}/foo/bar/
+neuro rm storage:///foo/bar
+neuro rm storage:/foo/bar
+neuro rm storage://{username}/foo/bar
+neuro rm --recursive storage://{username}/foo/
 
 ```
 
@@ -1387,6 +1450,7 @@ neuro rm storage://{username}/foo/bar/
 
 Name | Description|
 |----|------------|
+|_\-r, --recursive_|remove directories and their contents recursively|
 |_--help_|Show this message and exit.|
 
 
@@ -1399,13 +1463,14 @@ Make directories.
 **Usage:**
 
 ```bash
-neuro mkdir [OPTIONS] PATH
+neuro mkdir [OPTIONS] PATHS...
 ```
 
 **Options:**
 
 Name | Description|
 |----|------------|
+|_\-p, --parents_|No error if existing, make parent directories as needed|
 |_--help_|Show this message and exit.|
 
 
@@ -1418,7 +1483,7 @@ Move or rename files and directories.<br/><br/>SOURCE must contain path to the f
 **Usage:**
 
 ```bash
-neuro mv [OPTIONS] SOURCE DESTINATION
+neuro mv [OPTIONS] SOURCES... DESTINATION
 ```
 
 **Examples:**

--- a/neuromation/api/config.py
+++ b/neuromation/api/config.py
@@ -87,8 +87,6 @@ class _Config:
     cookie_session: _CookieSession
 
     def check_initialized(self) -> None:
-        if (
-            not self.auth_config.is_initialized()
-            or not self.cluster_config.is_initialized()
-        ):
+        # `cluster_config` is required
+        if not self.cluster_config.is_initialized():
             raise ValueError("Missing server configuration, need to login")

--- a/neuromation/api/config_factory.py
+++ b/neuromation/api/config_factory.py
@@ -84,6 +84,8 @@ class Factory:
             raise ConfigError(f"Config file {self._path} already exists. Please logout")
         async with _make_connector() as connector:
             config_unauthorized = await get_server_config(connector, url)
+            if not config_unauthorized.auth_config.is_initialized():
+                raise ConfigError("Cannot get server configuration")
             negotiator = AuthNegotiator(
                 connector, config_unauthorized.auth_config, show_browser_cb, timeout
             )
@@ -113,6 +115,8 @@ class Factory:
             raise ConfigError(f"Config file {self._path} already exists. Please logout")
         async with _make_connector() as connector:
             config_unauthorized = await get_server_config(connector, url)
+            if not config_unauthorized.auth_config.is_initialized():
+                raise ConfigError("Cannot get server configuration")
             negotiator = HeadlessNegotiator(
                 connector, config_unauthorized.auth_config, get_auth_code_cb, timeout
             )

--- a/neuromation/api/login.py
+++ b/neuromation/api/login.py
@@ -463,6 +463,7 @@ class BaseNegotiator(abc.ABC):
         config: _AuthConfig,
         timeout: aiohttp.ClientTimeout,
     ) -> None:
+        assert config.is_initialized(), "auth config is not initialized"
         self._config = config
         self._timeout = timeout
         self._connector = connector

--- a/tests/api/test_config.py
+++ b/tests/api/test_config.py
@@ -83,18 +83,17 @@ class TestConfig:
             url=URL("https://dev.neu.ro"),
             cookie_session=_CookieSession.create_uninitialized(),
         )
-        with pytest.raises(ValueError, match="Missing server configuration"):
-            config.check_initialized()
+        config.check_initialized()  # check no exceptions
 
     def test_check_initialized_bad_cluster_config(self) -> None:
-        auth_config_bad = _AuthConfig.create(
+        auth_config_good = _AuthConfig.create(
             auth_url=URL("auth_url"),
             token_url=URL("http://token"),
             client_id="client-id",
             audience="everyone",
             headless_callback_url=URL("https://dev.neu.ro/oauth/show-code"),
         )
-        assert auth_config_bad.is_initialized()
+        assert auth_config_good.is_initialized()
 
         cluster_config_good = _ClusterConfig.create(
             registry_url=URL(),  # empty
@@ -106,7 +105,7 @@ class TestConfig:
         assert not cluster_config_good.is_initialized()
 
         config = _Config(
-            auth_config=auth_config_bad,
+            auth_config=auth_config_good,
             auth_token=_AuthToken(
                 token="token", expiration_time=10, refresh_token="ok"
             ),

--- a/tests/api/test_login.py
+++ b/tests/api/test_login.py
@@ -630,6 +630,26 @@ class TestAuthNegotiator:
         assert token.token == "test_access_token_refreshed"
         assert token.refresh_token == "test_refresh_token"
 
+    def test_cannot_create_from_uninitialized_config(
+        self, connector: aiohttp.BaseConnector
+    ) -> None:
+        auth_config_bad = _AuthConfig.create(
+            auth_url=URL(),
+            token_url=URL(),
+            client_id="",
+            audience="",
+            headless_callback_url=URL(),
+        )
+        assert not auth_config_bad.is_initialized()
+
+        with pytest.raises(AssertionError, match="auth config is not initialized"):
+            AuthNegotiator(
+                connector,
+                config=auth_config_bad,
+                show_browser_cb=self.show_dummy_browser,
+                timeout=DEFAULT_TIMEOUT,
+            )
+
 
 class TestHeadlessNegotiator:
     async def test_get_code(
@@ -672,3 +692,26 @@ class TestHeadlessNegotiator:
         )
         with pytest.raises(RuntimeError, match="callback error"):
             await negotiator.get_code()
+
+    def test_cannot_create_from_uninitialized_config(
+        self, connector: aiohttp.BaseConnector
+    ) -> None:
+        async def get_auth_code_cb(url: URL) -> str:
+            pass
+
+        auth_config_bad = _AuthConfig.create(
+            auth_url=URL(),
+            token_url=URL(),
+            client_id="",
+            audience="",
+            headless_callback_url=URL(),
+        )
+        assert not auth_config_bad.is_initialized()
+
+        with pytest.raises(AssertionError, match="auth config is not initialized"):
+            HeadlessNegotiator(
+                connector,
+                config=auth_config_bad,
+                get_auth_code_cb=get_auth_code_cb,
+                timeout=DEFAULT_TIMEOUT,
+            )


### PR DESCRIPTION
Client-side support for changes introduced in https://github.com/neuromation/platform-api/pull/657: server is allowed to send an empty dictionary.