### PR TITLE
Fix version checker

### DIFF
--- a/CHANGELOG.D/826.bugfix
+++ b/CHANGELOG.D/826.bugfix
@@ -1,0 +1,1 @@
+Don't run version checks if config is not loaded by CLI command.

--- a/neuromation/cli/utils.py
+++ b/neuromation/cli/utils.py
@@ -110,7 +110,7 @@ async def _run_async_function(
             # Later the checker initialization code will be refactored
             # as a part of config reimplementation
             version_checker = VersionChecker(version)  # pragma: no cover
-        task: Optional["Task[None]"] = loop.create_task(version_checker.run())
+        task: Optional["asyncio.Task[None]"] = loop.create_task(version_checker.run())
     else:
         task = None
 


### PR DESCRIPTION
Don't run version checks if config is not loaded by CLI command