### PR TITLE
Make `neuro storage mv` more consistent with `mv`.

### DIFF
--- a/CHANGELOG.D/203.feature
+++ b/CHANGELOG.D/203.feature
@@ -1,0 +1,1 @@
+The behavior of the `neuro storage mv` is now closer to the behavior of the `mv` command.  It now movies files inside the target directory if it exists and movies a file under the new name otherwise.  Added also options `--target-directory` (`-t`) and `--no-target-directory` (`-T`).

--- a/README.md
+++ b/README.md
@@ -597,7 +597,7 @@ Move or rename files and directories.<br/><br/>SOURCE must contain path to the f
 **Usage:**
 
 ```bash
-neuro storage mv [OPTIONS] SOURCES... DESTINATION
+neuro storage mv [OPTIONS] [SOURCES]... [DESTINATION]
 ```
 
 **Examples:**
@@ -618,6 +618,8 @@ neuro mv storage://{username}/foo/ storage://{username}/bar/baz/foo/
 
 Name | Description|
 |----|------------|
+|_\-t, --target-directory DIRECTORY_|Copy all SOURCES into DIRECTORY|
+|_\-T, --no-target-directory_|Treat DESTINATION as a normal file|
 |_--help_|Show this message and exit.|
 
 
@@ -1513,7 +1515,7 @@ Move or rename files and directories.<br/><br/>SOURCE must contain path to the f
 **Usage:**
 
 ```bash
-neuro mv [OPTIONS] SOURCES... DESTINATION
+neuro mv [OPTIONS] [SOURCES]... [DESTINATION]
 ```
 
 **Examples:**
@@ -1534,6 +1536,8 @@ neuro mv storage://{username}/foo/ storage://{username}/bar/baz/foo/
 
 Name | Description|
 |----|------------|
+|_\-t, --target-directory DIRECTORY_|Copy all SOURCES into DIRECTORY|
+|_\-T, --no-target-directory_|Treat DESTINATION as a normal file|
 |_--help_|Show this message and exit.|
 
 

--- a/tests/e2e/test_e2e_storage.py
+++ b/tests/e2e/test_e2e_storage.py
@@ -345,3 +345,124 @@ def test_e2e_copy_recursive_to_platform(
 
     # And confirm
     helper.check_dir_absent_on_storage("nested", "")
+
+
+@pytest.mark.e2e
+def test_e2e_rename(helper: Helper) -> None:
+    helper.check_create_dir_on_storage("folder")
+    helper.run_cli(
+        [
+            "storage",
+            "mv",
+            helper.tmpstorage + "folder",
+            helper.tmpstorage + "otherfolder",
+        ]
+    )
+    helper.check_dir_absent_on_storage("folder", "")
+    helper.check_dir_exists_on_storage("otherfolder", "")
+
+
+@pytest.mark.e2e
+def test_e2e_move_to_directory(helper: Helper) -> None:
+    helper.check_create_dir_on_storage("folder")
+    helper.check_create_dir_on_storage("otherfolder")
+    helper.run_cli(
+        [
+            "storage",
+            "mv",
+            helper.tmpstorage + "folder",
+            helper.tmpstorage + "otherfolder",
+        ]
+    )
+    helper.check_dir_absent_on_storage("folder", "")
+    helper.check_dir_exists_on_storage("otherfolder", "")
+    helper.check_dir_exists_on_storage("folder", "otherfolder")
+
+
+@pytest.mark.e2e
+def test_e2e_move_to_directory_explicitly(helper: Helper) -> None:
+    helper.check_create_dir_on_storage("folder")
+    helper.check_create_dir_on_storage("otherfolder")
+    helper.run_cli(
+        [
+            "storage",
+            "mv",
+            "-t",
+            helper.tmpstorage + "otherfolder",
+            helper.tmpstorage + "folder",
+        ]
+    )
+    helper.check_dir_absent_on_storage("folder", "")
+    helper.check_dir_exists_on_storage("otherfolder", "")
+    helper.check_dir_exists_on_storage("folder", "otherfolder")
+
+
+@pytest.mark.e2e
+def test_e2e_move_content_to_directory(helper: Helper) -> None:
+    helper.check_create_dir_on_storage("folder")
+    helper.check_create_dir_on_storage("folder/subfolder")
+    helper.check_create_dir_on_storage("otherfolder")
+    helper.run_cli(
+        [
+            "storage",
+            "mv",
+            "-T",
+            helper.tmpstorage + "folder",
+            helper.tmpstorage + "otherfolder",
+        ]
+    )
+    helper.check_dir_absent_on_storage("folder", "")
+    helper.check_dir_exists_on_storage("subfolder", "otherfolder")
+
+
+@pytest.mark.e2e
+def test_e2e_move_no_sources_no_destination(helper: Helper) -> None:
+    with pytest.raises(subprocess.CalledProcessError) as cm:
+        helper.run_cli(["storage", "mv"])
+    assert 'Missing argument "DESTINATION"' in cm.value.stderr
+
+
+@pytest.mark.e2e
+def test_e2e_move_no_sources(helper: Helper) -> None:
+    with pytest.raises(subprocess.CalledProcessError) as cm:
+        helper.run_cli(["storage", "mv", helper.tmpstorage])
+    assert 'Missing argument "SOURCES..."' in cm.value.stderr
+
+
+@pytest.mark.e2e
+def test_e2e_move_no_sources_target_directory(helper: Helper) -> None:
+    with pytest.raises(subprocess.CalledProcessError) as cm:
+        helper.run_cli(["storage", "mv", "-t", helper.tmpstorage])
+    assert 'Missing argument "SOURCES..."' in cm.value.stderr
+
+
+@pytest.mark.e2e
+def test_e2e_move_target_directory_no_target_directory(helper: Helper) -> None:
+    with pytest.raises(subprocess.CalledProcessError) as cm:
+        helper.run_cli(
+            [
+                "storage",
+                "mv",
+                "-t",
+                helper.tmpstorage + "/foo",
+                "-T",
+                helper.tmpstorage + "/bar",
+            ]
+        )
+    assert "Cannot combine" in cm.value.stderr
+
+
+@pytest.mark.e2e
+def test_e2e_move_no_target_directory_extra_operand(helper: Helper) -> None:
+    with pytest.raises(subprocess.CalledProcessError) as cm:
+        helper.run_cli(
+            [
+                "storage",
+                "mv",
+                "-T",
+                helper.tmpstorage + "/foo",
+                helper.tmpstorage + "/bar",
+                helper.tmpstorage + "/baz",
+            ]
+        )
+    assert "Extra operand after " in cm.value.stderr


### PR DESCRIPTION
It now moves files inside the target directory if it exists and moves a file under the new name otherwise.

Added also options `--target-directory` (`-t`) and `--no-target-directory` (`-T`). They allow the behavior to not be depended on the existence of the target directory.

Closes #203.