### PR TITLE
Minor update of certifi error message. (#845)

### DIFF
--- a/neuromation/cli/utils.py
+++ b/neuromation/cli/utils.py
@@ -87,6 +87,7 @@ def warn_if_has_newer_version(
             fg="red",
         )
 
+
 async def _run_async_function(
     init_client: bool,
     func: Callable[..., Awaitable[_T]],


### PR DESCRIPTION
Added conda upgrade command.
The major point here is to get rid of an impression that upgrading through pip is the only viable option.