### PR TITLE
Remove neuro-sdk/neuro-cli backward compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -222,14 +222,10 @@ jobs:
         run: |
           cd apolo-sdk
           python -m build
-          sed -i 's/name = apolo-sdk/name = neuro-sdk/g' setup.cfg
-          python -m build -o dist-neuro
       - name: Make CLI dists
         run: |
           cd apolo-cli
           python -m build
-          sed -i 's/name = apolo-cli/name = neuro-cli/g' setup.cfg
-          python -m build -o dist-neuro
       - name: PyPI upload SDK
         env:
           TWINE_USERNAME: __token__
@@ -244,22 +240,6 @@ jobs:
           TWINE_NON_INTERACTIVE: 1
         run: |
           twine upload apolo-cli/dist/*
-      - name: PyPI upload neuro SDK
-        # for backward compatibility
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN_SDK_NEURO }}
-          TWINE_NON_INTERACTIVE: 1
-        run: |
-          twine upload apolo-sdk/dist-neuro/*
-      - name: PyPI upload neuro CLI
-        # for backward compatibility
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN_CLI_NEURO }}
-          TWINE_NON_INTERACTIVE: 1
-        run: |
-          twine upload apolo-cli/dist-neuro/*
       - name: Merge dists for GitHub Release
         run: |
           mkdir dist

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -4,5 +4,5 @@
     directory = "CHANGELOG.D"
     filename = "CHANGELOG.md"
     name = "Apolo SDK/CLI"
-    issue_format = "[#{issue}](https://github.com/neuro-inc/neuro-cli/issues/{issue})"
+    issue_format = "[#{issue}](https://github.com/neuro-inc/apolo-cli/issues/{issue})"
     start_string = "[comment]: # (towncrier release notes start)\n"


### PR DESCRIPTION
## Summary
- Remove duplicate PyPI uploads for neuro-sdk and neuro-cli packages from CI workflow
- Update towncrier issue URL to use correct apolo-cli repository

## Test plan
- [ ] CI workflow runs successfully without the removed steps
- [ ] Towncrier generates changelogs with correct issue links