### PR TITLE
Display app info when installing

### DIFF
--- a/CHANGELOG.D/3285.feature.md
+++ b/CHANGELOG.D/3285.feature.md
@@ -1,0 +1,1 @@
+Use AppsFormatter to print information about the app being currently installed such as App Instance ID, App Name and Template Name

--- a/apolo-cli/src/apolo_cli/apps.py
+++ b/apolo-cli/src/apolo_cli/apps.py
@@ -145,18 +145,23 @@ async def install(
     """
     Install an app from a YAML file.
     """
+    if root.quiet:
+        apps_fmtr: BaseAppsFormatter = SimpleAppsFormatter()
+    else:
+        apps_fmtr = AppsFormatter()
 
     with open(file_path) as file:
         app_data = yaml.safe_load(file)
 
     try:
         with root.status(f"Installing app from [bold]{file_path}[/bold]"):
-            await root.client.apps.install(
+            resp = await root.client.apps.install(
                 app_data=app_data,
                 cluster_name=cluster,
                 org_name=org,
                 project_name=project,
             )
+            root.print(apps_fmtr([resp]))
     except IllegalArgumentError as e:
         if e.payload and e.payload.get("errors") and root.verbosity >= 0:
             root.print("[red]Input validation error:[/red]", markup=True)
@@ -168,7 +173,7 @@ async def install(
         raise e
 
     if not root.quiet:
-        root.print(f"App installed from [bold]{file_path}[/bold]", markup=True)
+        root.print(f"App installed from [bold]{file_path}[/bold].", markup=True)
 
 
 @command()

--- a/apolo-cli/tests/unit/test_apps.py
+++ b/apolo-cli/tests/unit/test_apps.py
@@ -30,8 +30,17 @@ def mock_apps_install() -> Iterator[None]:
     """Context manager to mock the Apps.install method."""
     with mock.patch.object(Apps, "install") as mocked:
 
-        async def install(**kwargs: Any) -> str:
-            return "app-123"
+        async def install(**kwargs: Any) -> App:
+            return App(
+                id="app-123",
+                name="test-app-1",
+                display_name="Test App 1",
+                template_name="test-template",
+                template_version="1.0",
+                project_name="test-project",
+                org_name="test-org",
+                state="running",
+            )
 
         mocked.side_effect = install
         yield

--- a/apolo-cli/tests/unit/test_shell_completion.py
+++ b/apolo-cli/tests/unit/test_shell_completion.py
@@ -1576,6 +1576,8 @@ def test_app_autocomplete(run_autocomplete: _RunAC) -> None:
     zsh_out, bash_out = run_autocomplete(["app", ""])
     assert "ls" in bash_out
     assert "ls" in zsh_out
+    assert "install" in bash_out
+    assert "install" in zsh_out
     assert "uninstall" in bash_out
     assert "uninstall" in zsh_out
     assert "get-values" in bash_out

--- a/apolo-sdk/docs/apps.rst
+++ b/apolo-sdk/docs/apps.rst
@@ -22,6 +22,26 @@ Apps
       :param str org_name: org to list applications. Default is current org.
       :param str project_name: project to list applications. Default is current project.
 
+   .. method:: install(app_data: dict, cluster_name: Optional[str] = None, org_name: Optional[str] = None, project_name: Optional[str] = None) -> App
+      :async:
+
+      Install a new application instance from template data.
+
+      :param dict app_data: Dictionary containing application installation data.
+      :param str cluster_name: cluster to install application. Default is current cluster.
+      :param str org_name: org to install application. Default is current org.
+      :param str project_name: project to install application. Default is current project.
+
+   .. method:: uninstall(app_id: str, cluster_name: Optional[str] = None, org_name: Optional[str] = None, project_name: Optional[str] = None) -> None
+      :async:
+
+      Uninstall an application instance.
+
+      :param str app_id: The ID of the application instance to uninstall.
+      :param str cluster_name: cluster where the application is deployed. Default is current cluster.
+      :param str org_name: org where the application is deployed. Default is current org.
+      :param str project_name: project where the application is deployed. Default is current project.
+
    .. method:: list_templates(cluster_name: Optional[str] = None, org_name: Optional[str] = None, project_name: Optional[str] = None) -> AsyncContextManager[AsyncIterator[AppTemplate]]
       :async:
 
@@ -74,6 +94,26 @@ Apps
       :param str project_name: Project where the app is deployed. Default is current project.
       :param datetime since: Optional timestamp to start logs from.
       :param bool timestamps: Include timestamps in the logs output.
+
+   .. method:: install(app_data: dict, cluster_name: Optional[str] = None, org_name: Optional[str] = None, project_name: Optional[str] = None) -> App
+      :async:
+
+      Install a new application instance from template data.
+
+      :param dict app_data: Dictionary containing application installation data.
+      :param str cluster_name: cluster to install application. Default is current cluster.
+      :param str org_name: org to install application. Default is current org.
+      :param str project_name: project to install application. Default is current project.
+
+   .. method:: uninstall(app_id: str, cluster_name: Optional[str] = None, org_name: Optional[str] = None, project_name: Optional[str] = None) -> None
+      :async:
+
+      Uninstall an application instance.
+
+      :param str app_id: The ID of the application instance to uninstall.
+      :param str cluster_name: cluster where the application is deployed. Default is current cluster.
+      :param str org_name: org where the application is deployed. Default is current org.
+      :param str project_name: project where the application is deployed. Default is current project.
 
 ===
 

--- a/apolo-sdk/docs/apps.rst
+++ b/apolo-sdk/docs/apps.rst
@@ -95,16 +95,6 @@ Apps
       :param datetime since: Optional timestamp to start logs from.
       :param bool timestamps: Include timestamps in the logs output.
 
-   .. method:: install(app_data: dict, cluster_name: Optional[str] = None, org_name: Optional[str] = None, project_name: Optional[str] = None) -> App
-      :async:
-
-      Install a new application instance from template data.
-
-      :param dict app_data: Dictionary containing application installation data.
-      :param str cluster_name: cluster to install application. Default is current cluster.
-      :param str org_name: org to install application. Default is current org.
-      :param str project_name: project to install application. Default is current project.
-
    .. method:: uninstall(app_id: str, cluster_name: Optional[str] = None, org_name: Optional[str] = None, project_name: Optional[str] = None) -> None
       :async:
 

--- a/apolo-sdk/src/apolo_sdk/_apps.py
+++ b/apolo-sdk/src/apolo_sdk/_apps.py
@@ -124,7 +124,7 @@ class Apps(metaclass=NoPublicConstructor):
         cluster_name: Optional[str] = None,
         org_name: Optional[str] = None,
         project_name: Optional[str] = None,
-    ) -> None:
+    ) -> App:
         url = (
             self._build_base_url(
                 cluster_name=cluster_name,
@@ -135,8 +135,18 @@ class Apps(metaclass=NoPublicConstructor):
         )
 
         auth = await self._config._api_auth()
-        async with self._core.request("POST", url, json=app_data, auth=auth):
-            pass
+        async with self._core.request("POST", url, json=app_data, auth=auth) as resp:
+            item = await resp.json()
+            return App(
+                id=item.get("id"),
+                name=item.get("name"),
+                display_name=item.get("display_name"),
+                template_name=item.get("template_name"),
+                template_version=item.get("template_version"),
+                project_name=item.get("project_name"),
+                org_name=item.get("org_name"),
+                state=item.get("state"),
+            )
 
     async def uninstall(
         self,

--- a/apolo-sdk/src/apolo_sdk/_apps.py
+++ b/apolo-sdk/src/apolo_sdk/_apps.py
@@ -136,6 +136,7 @@ class Apps(metaclass=NoPublicConstructor):
 
         auth = await self._config._api_auth()
         async with self._core.request("POST", url, json=app_data, auth=auth) as resp:
+            resp.raise_for_status()
             item = await resp.json()
             return App(
                 id=item.get("id"),

--- a/apolo-sdk/tests/test_apps.py
+++ b/apolo-sdk/tests/test_apps.py
@@ -91,11 +91,21 @@ async def test_apps_install(
     }
 
     async def handler(request: web.Request) -> web.Response:
+        response_data = {
+                "id": "id",
+                "name": "name",
+                "display_name": "display_name",
+                "template_name": "template_name",
+                "template_version": "template_version",
+                "project_name": "project_name",
+                "org_name": "org_name",
+                "state": "state",
+        }
         assert request.method == "POST"
         url = "/apis/apps/v1/cluster/default/org/superorg/project/test3/instances"
         assert request.path == url
         assert await request.json() == app_data
-        return web.Response(status=201, content_type="application/json")
+        return web.json_response(data=response_data, status=201)
 
     web_app = web.Application()
     web_app.router.add_post(

--- a/apolo-sdk/tests/test_apps.py
+++ b/apolo-sdk/tests/test_apps.py
@@ -92,14 +92,14 @@ async def test_apps_install(
 
     async def handler(request: web.Request) -> web.Response:
         response_data = {
-                "id": "id",
-                "name": "name",
-                "display_name": "display_name",
-                "template_name": "template_name",
-                "template_version": "template_version",
-                "project_name": "project_name",
-                "org_name": "org_name",
-                "state": "state",
+            "id": "id",
+            "name": "name",
+            "display_name": "display_name",
+            "template_name": "template_name",
+            "template_version": "template_version",
+            "project_name": "project_name",
+            "org_name": "org_name",
+            "state": "state",
         }
         assert request.method == "POST"
         url = "/apis/apps/v1/cluster/default/org/superorg/project/test3/instances"

--- a/apolo-sdk/tests/test_apps.py
+++ b/apolo-sdk/tests/test_apps.py
@@ -95,7 +95,7 @@ async def test_apps_install(
         url = "/apis/apps/v1/cluster/default/org/superorg/project/test3/instances"
         assert request.path == url
         assert await request.json() == app_data
-        return web.Response(status=201)
+        return web.Response(status=201, content_type="application/json")
 
     web_app = web.Application()
     web_app.router.add_post(


### PR DESCRIPTION
# What this PR does

Currently when a user install an App using the CLI they get no info about the installed App: no id, nothing. They need to list existing apps to try to find the latest instance they installed.

This PR uses AppsFormatter to print information about the app being currently installed.

This is the result: 

```shell
❯ apolo app install --file myservice.yaml
                                                                                                                                                   
  ID                                     Name                                          Display Name         Template             Version   State   
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 
  f178e302-8190-4abd-b566-cf8fdceb98e6   apolo-jordy-dev-service-deployment-f178e302   Service Deployment   service-deployment   v25.5.1   queued  
                                                                                                                                                   
App installed from myservice.yaml.
```