### PR TITLE
IT-114: Accept all manifest media types when resolving image digests

### DIFF
--- a/CHANGELOG.D/3489.bugfix
+++ b/CHANGELOG.D/3489.bugfix
@@ -1,0 +1,1 @@
+Fixed `apolo image rm` and `apolo image size` failing with `ResourceNotFound` for images stored as OCI manifests (e.g. built by kaniko via `apolo-flow build`): all standard manifest media types are now accepted when resolving image digests.

--- a/apolo-sdk/src/apolo_sdk/_images.py
+++ b/apolo-sdk/src/apolo_sdk/_images.py
@@ -32,6 +32,18 @@ TAGS_PER_PAGE = 30
 
 DEFAULT_PUSH_TIMEOUT = 20 * 60  # 20 minutes
 
+# the registry returns 404 for manifests whose stored media type
+# is not listed in Accept, so all known types must be accepted
+# (e.g. kaniko pushes OCI manifests)
+MANIFEST_ACCEPT = ", ".join(
+    (
+        "application/vnd.docker.distribution.manifest.v2+json",
+        "application/vnd.docker.distribution.manifest.list.v2+json",
+        "application/vnd.oci.image.manifest.v1+json",
+        "application/vnd.oci.image.index.v1+json",
+    )
+)
+
 log = logging.getLogger(__package__)
 
 
@@ -135,7 +147,7 @@ class Images(metaclass=NoPublicConstructor):
             "HEAD",
             url,
             auth=auth,
-            headers={"Accept": "application/vnd.docker.distribution.manifest.v2+json"},
+            headers={"Accept": MANIFEST_ACCEPT},
         ) as resp:
             return resp.headers["Docker-Content-Digest"]
 
@@ -152,7 +164,7 @@ class Images(metaclass=NoPublicConstructor):
             "GET",
             url,
             auth=auth,
-            headers={"Accept": "application/vnd.docker.distribution.manifest.v2+json"},
+            headers={"Accept": MANIFEST_ACCEPT},
         ) as resp:
             data = await resp.json()
             size = sum(layer["size"] for layer in data["layers"])

--- a/apolo-sdk/tests/test_images.py
+++ b/apolo-sdk/tests/test_images.py
@@ -1574,10 +1574,11 @@ class TestRegistry:
         }
 
         async def handler(request: web.Request) -> web.Response:
-            assert (
-                request.headers["Accept"]
-                == "application/vnd.docker.distribution.manifest.v2+json"
-            )
+            accept = request.headers["Accept"]
+            assert "application/vnd.docker.distribution.manifest.v2+json" in accept
+            assert "application/vnd.docker.distribution.manifest.list.v2+json" in accept
+            assert "application/vnd.oci.image.manifest.v1+json" in accept
+            assert "application/vnd.oci.image.index.v1+json" in accept
             return web.json_response(JSON)
 
         app = web.Application()
@@ -1600,6 +1601,47 @@ class TestRegistry:
             assert image.tag
 
         assert ret == Tag(name=image.tag, size=32890532)
+
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="aiodocker doesn't support Windows pipes yet"
+    )
+    async def test_digest_oci_manifest(
+        self, aiohttp_server: _TestServerFactory, make_client: _MakeClient
+    ) -> None:
+        # the registry returns 404 for manifests whose stored media type
+        # is not listed in Accept; kaniko-built images store OCI manifests
+        oci_media_type = "application/vnd.oci.image.manifest.v1+json"
+        digest = "sha256:" + "0" * 64
+
+        async def handler(request: web.Request) -> web.Response:
+            if oci_media_type not in request.headers["Accept"]:
+                return web.json_response({}, status=404)
+            return web.Response(
+                headers={
+                    "Content-Type": oci_media_type,
+                    "Docker-Content-Digest": digest,
+                }
+            )
+
+        app = web.Application()
+        app.router.add_head("/v2/project/test/manifests/test_tag", handler)
+
+        srv = await aiohttp_server(app)
+        url = "http://platform"
+        registry_url = srv.make_url("/v2/")
+
+        async with make_client(url, registry_url=registry_url) as client:
+            image = RemoteImage.new_platform_image(
+                name="test",
+                tag="test_tag",
+                cluster_name="default",
+                registry="reg",
+                org_name=None,
+                project_name="project",
+            )
+            ret = await client.images.digest(image)
+
+        assert ret == digest
 
     @pytest.mark.skipif(
         sys.platform == "win32", reason="aiodocker doesn't support Windows pipes yet"


### PR DESCRIPTION
## Summary

Fixes the client half of [IT-114](https://apolocloud.atlassian.net/browse/IT-114): `apolo image rm` (and `apolo image size`) failed with `ResourceNotFound` for images that `apolo image ls` shows.

Root cause: the registry honors content negotiation and returns 404 for manifests whose stored media type is not listed in `Accept`. `images.digest()` and `images.tag_info()` sent only `application/vnd.docker.distribution.manifest.v2+json`, so any kaniko-built image — stored as an **OCI manifest** (i.e. everything produced by `apolo-flow build` / apolo-extras) — could not be resolved, while docker-pushed images worked. The fix sends the standard full list (Docker v2, Docker manifest list, OCI manifest, OCI index), matching docker/containerd behavior.

Verified against the dev cluster registry: HEAD with the old header → 404, with the new list → 200 + digest; with the patched SDK `apolo image rm` resolves the digest and the delete reaches the registry.

Note: on the dev cluster the subsequent DELETE is then rejected by the platform-registry service with `FORBIDDEN: CSRF token not found` — a separate server-side issue (the service sets a session cookie on GET/HEAD, the SDK's cookie jar returns it on DELETE, and the CSRF middleware rejects; docker isn't affected because it doesn't keep cookies). A cookieless DELETE succeeds (HTTP 202). Tracked in IT-114 as the remaining server-side half.

## Test plan

- new `test_digest_oci_manifest`: server 404s unless the OCI media type is accepted — fails on the old code, passes now
- `test_tag_info` updated to assert all four media types are sent
- `apolo-sdk/tests/test_images.py`: 158 passed, 2 pre-existing failures identical on master (docker-socket env)
- black/flake8/isort clean

[IT-114]: https://apolocloud.atlassian.net/browse/IT-114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ