### PR TITLE
IT-88: fix acl ls help wording and SCREAMING_SNAKE_CASE rendering in generated docs

### DIFF
--- a/CHANGELOG.D/3506.bugfix
+++ b/CHANGELOG.D/3506.bugfix
@@ -1,0 +1,1 @@
+Fixed `apolo acl ls` help text, which described the default output and the `--shared` output the wrong way round.

--- a/CHANGELOG.D/3506.doc
+++ b/CHANGELOG.D/3506.doc
@@ -1,0 +1,1 @@
+Stopped the docs generator from splitting `SCREAMING_SNAKE_CASE` identifiers across several code spans, so metavars such as `APOLO_PASSED_CONFIG`, `SERVICE_ACCOUNT` and `APP_ID` now render as one.

--- a/CLI.md
+++ b/CLI.md
@@ -371,7 +371,7 @@ Name | Description|
 
 ### apolo acl ls
 
-List shared resources.<br/><br/>The command displays a list of resources shared BY current user \(default).<br/><br/>To display a list of resources shared WITH current user apply --shared option.<br/><br/>Use `\-u/--username` to fetch roles of a specified user or role.<br/>
+List shared resources.<br/><br/>The command displays a list of resources available TO current user \(default).<br/><br/>To display a list of resources shared BY current user, along with the users<br/>and roles they are shared with, apply --shared option.<br/><br/>Use `\-u/--username` to fetch roles of a specified user or role.<br/>
 
 **Usage:**
 

--- a/apolo-cli/docs/acl.md
+++ b/apolo-cli/docs/acl.md
@@ -125,14 +125,15 @@ apolo acl ls [OPTIONS] [URI]
 
 List shared resources.
 
-The command displays a list of resources shared BY
+The command displays a list of resources available TO
 current user (default).
 
-To display a list of resources shared `WITH` current
-user apply --shared option.
+To display a list of resources shared BY current
+user, along with the users and
+roles they are shared with, apply --shared
+option.
 
-Use `-u/--username` to fetch roles of a specified
-user or role.
+Use `-u/--username` to fetch roles of a specified user or role.
 
 #### Examples
 

--- a/apolo-cli/docs/app.md
+++ b/apolo-cli/docs/app.md
@@ -62,7 +62,7 @@ apolo app get-input [OPTIONS] APP_ID
 
 Get input for an app.
 
-`APP`_ID: ID of the app to get input for.
+`APP_ID`: ID of the app to get input for.
 
 #### Options
 
@@ -90,7 +90,7 @@ apolo app get-revisions [OPTIONS] APP_ID
 
 Get configuration revisions for an app.
 
-`APP`_ID: ID of the app to get
+`APP_ID`: ID of the app to get
 configuration revisions for.
 
 #### Options
@@ -115,7 +115,7 @@ apolo app get-status [OPTIONS] APP_ID
 
 Get status events for an app.
 
-`APP`_ID: ID of the app to get status for
+`APP_ID`: ID of the app to get status for
 status events.
 
 #### Options
@@ -143,7 +143,7 @@ apolo app get-values [OPTIONS] [APP_ID]
 
 Get application values.
 
-`APP`_ID: Optional ID of the app to get values for.
+`APP_ID`: Optional ID of the app to get values for.
 
 #### Options
 
@@ -274,8 +274,8 @@ apolo app rollback [OPTIONS] APP_ID REVISION_NUMBER
 
 Rollback application configuration.
 
-`APP`_ID: ID of the app to rollback.
-`REVISION`_`NUMBER`: Target revision number.
+`APP_ID`: ID of the app to rollback.
+`REVISION_NUMBER`: Target revision number.
 
 #### Options
 
@@ -302,7 +302,7 @@ apolo app uninstall [OPTIONS] APP_ID
 
 Uninstall an app.
 
-`APP`_ID: ID of the app to uninstall
+`APP_ID`: ID of the app to uninstall
 
 #### Options
 

--- a/apolo-cli/docs/blob.md
+++ b/apolo-cli/docs/blob.md
@@ -356,7 +356,7 @@ Remove bucket credential BUCKET_CREDENTIAL
 apolo blob rmcredentials [OPTIONS] CREDENTIALS...
 ```
 
-Remove bucket credential `BUCKET`_`CREDENTIAL`.
+Remove bucket credential `BUCKET_CREDENTIAL`.
 
 #### Options
 
@@ -457,7 +457,7 @@ Get bucket credential BUCKET_CREDENTIAL
 apolo blob statcredentials [OPTIONS] BUCKET_CREDENTIAL
 ```
 
-Get bucket credential `BUCKET`_`CREDENTIAL`.
+Get bucket credential `BUCKET_CREDENTIAL`.
 
 #### Options
 

--- a/apolo-cli/docs/config.md
+++ b/apolo-cli/docs/config.md
@@ -257,8 +257,8 @@ apolo config switch-cluster [OPTIONS] [CLUSTER_NAME]
 
 Switch the active cluster.
 
-`CLUSTER`_`NAME` is the cluster name to select.
-The interactive prompt is used if the
+`CLUSTER_NAME` is the cluster name to select.  The
+interactive prompt is used if the
 name is omitted (default).
 
 #### Options
@@ -282,7 +282,7 @@ apolo config switch-org [OPTIONS] ORG_NAME
 
 Switch the active organization.
 
-`ORG`_`NAME` is the organization name to
+`ORG_NAME` is the organization name to
 select.
 
 #### Options
@@ -306,8 +306,8 @@ apolo config switch-project [OPTIONS] [PROJECT_NAME]
 
 Switch the active project.
 
-`PROJECT`_`NAME` is the project name to select.
-The interactive prompt is used if the
+`PROJECT_NAME` is the project name to select. The
+interactive prompt is used if the
 name is omitted (default).
 
 #### Options

--- a/apolo-cli/docs/disk.md
+++ b/apolo-cli/docs/disk.md
@@ -80,7 +80,7 @@ Get disk DISK_ID
 apolo disk get [OPTIONS] DISK
 ```
 
-Get disk `DISK`_ID.
+Get disk `DISK_ID`.
 
 #### Options
 
@@ -133,7 +133,7 @@ Remove disk DISK_ID
 apolo disk rm [OPTIONS] DISKS...
 ```
 
-Remove disk `DISK`_ID.
+Remove disk `DISK_ID`.
 
 #### Options
 

--- a/apolo-cli/docs/service-account.md
+++ b/apolo-cli/docs/service-account.md
@@ -42,9 +42,9 @@ use a secure channel.
 
 The `CLI` exposes two token forms:
 - a full passed-
-config token, which can be used as ``APOLO`_`PASSED`_`CONFIG``
-- a raw auth
-token, which can be used with `apolo config login-with-token`
+config token, which can be used as `APOLO_PASSED_CONFIG`
+- a raw auth token,
+which can be used with `apolo config login-with-token`
 
 #### Options
 
@@ -69,7 +69,7 @@ Get service account SERVICE_ACCOUNT
 apolo service-account get [OPTIONS] SERVICE_ACCOUNT
 ```
 
-Get service account `SERVICE`_`ACCOUNT`.
+Get service account `SERVICE_ACCOUNT`.
 
 The output includes the backing role
 used for `ACL` grants.
@@ -123,7 +123,7 @@ Remove service account SERVICE_ACCOUNT
 apolo service-account rm [OPTIONS] SERVICE_ACCOUNTS...
 ```
 
-Remove service account `SERVICE`_`ACCOUNT`.
+Remove service account `SERVICE_ACCOUNT`.
 
 #### Options
 

--- a/apolo-cli/src/apolo_cli/share.py
+++ b/apolo-cli/src/apolo_cli/share.py
@@ -124,9 +124,10 @@ async def ls(
     """
     List shared resources.
 
-    The command displays a list of resources shared BY current user (default).
+    The command displays a list of resources available TO current user (default).
 
-    To display a list of resources shared WITH current user apply --shared option.
+    To display a list of resources shared BY current user, along with the users and
+    roles they are shared with, apply --shared option.
 
     Use `-u/--username` to fetch roles of a specified user or role.
 

--- a/build-tools/site-help-generator.py
+++ b/build-tools/site-help-generator.py
@@ -21,6 +21,25 @@ def _process_help(help: str | None) -> str:
     return inspect.cleandoc(help or "").partition("\f")[0]
 
 
+# an already-quoted span is consumed by the first branch and passed through, so a
+# docstring that quotes an identifier itself does not end up double-quoted
+IDENTIFIER_RE = re.compile(r"`[^`]*`|([A-Z0-9\-]{3,60}(?:_[A-Z0-9\-]+)*)")
+
+
+def quote_identifiers(text: str) -> str:
+    """Wrap bare SCREAMING_SNAKE_CASE identifiers and metavars in backticks.
+
+    Underscores are part of the identifier: matching each run separately would
+    render APOLO_PASSED_CONFIG as `APOLO`_`PASSED`_`CONFIG`.
+    """
+
+    def repl(match: re.Match[str]) -> str:
+        ident = match.group(1)
+        return f"`{ident}`" if ident else match.group(0)
+
+    return IDENTIFIER_RE.sub(repl, text)
+
+
 def gen_command(out, cmd, parent_ctx):
     with click.Context(cmd, parent=parent_ctx, info_name=cmd.name) as ctx:
         out.append(f"### {cmd.name}\n")
@@ -41,7 +60,7 @@ def gen_command(out, cmd, parent_ctx):
 
         help, *examples = split_examples(_process_help(cmd.help))
         help2 = click.unstyle(help)
-        help3 = re.sub(r"([A-Z0-9\-]{3,60})", r"`\1`", help2)
+        help3 = quote_identifiers(help2)
         out.append(wrap_text(help3))
         out.append("")
 


### PR DESCRIPTION
Two documentation defects found while writing the Console-side service accounts docs for IT-88 ([apolo-documentation#9](https://github.com/neuro-inc/apolo-documentation/pull/9)). Both surface on published pages under `docs.apolo.us/index/apolo-cli/`.

## 1. `apolo acl ls` help had its two sentences swapped

The docstring claimed the default lists resources shared **BY** you and `--shared` lists resources shared **WITH** you. The implementation is the reverse:

- default → `users.get_acl(username)`, two columns (URI, action) — what the user can reach;
- `--shared` → `users.get_shares(username)`, three columns (URI, action, **user**) — what the user has shared, and with whom.

The `--shared` flag's own help string ("Output the resources shared by the user") already agreed with the implementation, so only the docstring prose was wrong. Reworded to match, and to mention the third column, since that is the reason to reach for the flag.

Verified against a live cluster: `apolo acl ls --shared` prints the grantee column, `apolo acl ls` does not.

## 2. `SCREAMING_SNAKE_CASE` identifiers were split across several code spans

`site-help-generator.py` wrapped runs matching `[A-Z0-9\-]{3,60}` in backticks. Underscore is not in that class, so every underscore-separated run got its own pair:

```
- a full passed-config token, which can be used as ``APOLO`_`PASSED`_`CONFIG``
Get service account `SERVICE`_`ACCOUNT`.
```

The identifier is now matched as a whole. This fixes six pages, not just `service-account` — `APP_ID`, `REVISION_NUMBER`, `BUCKET_CREDENTIAL`, `CLUSTER_NAME`, `ORG_NAME`, `PROJECT_NAME` and `DISK_ID` were all affected.

The regex also now consumes already-quoted spans and passes them through, so a docstring that quotes an identifier itself (as `service-account create` does) no longer comes out double-quoted as ` ``APOLO_PASSED_CONFIG`` `. The transform is idempotent, and every non-identifier case it handled before is byte-for-byte unchanged — including mixed-case text like `FOO_bar`, which still yields `` `FOO`_bar ``.

## Regenerated output

`apolo-cli/docs/*.md` and `CLI.md` are regenerated with `make docs` (`markdown-toc==1.2.6` from `requirements/mypy.txt`). The only `CLI.md` change is the `acl ls` paragraph, which confirms the local toolchain reproduces the committed output rather than reformatting it.

## Testing

`pytest apolo-cli/tests/unit -k "share or acl or service_account or help or docs"` gives **17 failed, 24 passed** both with and without this branch — the failures are pre-existing in my local py3.14 / click 8.4 environment and are unaffected by these changes. Leaving CI to be the real check.

## Not fixed here

`click.wrap_text` breaks at hyphens, so `passed-config` in the `service-account create` docstring still renders as "a full passed- config token" after the line rejoins. That is a separate wrapping issue affecting any hyphenated word landing on a wrap boundary; happy to take it in a follow-up if you want it.
