### PR TITLE
APS-412: Let the CLI apply a config written for another version

### DIFF
--- a/CHANGELOG.D/3522.feature
+++ b/CHANGELOG.D/3522.feature
@@ -1,0 +1,1 @@
+Applying a config written for another version of the same app with `apolo app configure` no longer fails on a version mismatch. Fields the installed version does not have are named instead.

--- a/apolo-sdk/src/apolo_sdk/_apps.py
+++ b/apolo-sdk/src/apolo_sdk/_apps.py
@@ -10,6 +10,7 @@ from yarl import URL
 
 from ._config import Config
 from ._core import _Core
+from ._errors import ResourceNotFound
 from ._rewrite import rewrite_module
 from ._utils import NoPublicConstructor, asyncgeneratorcontextmanager
 
@@ -97,6 +98,68 @@ class AppConfigurationRevision:
     comment: str | None
     created_at: datetime
     end_at: datetime | None
+
+
+def _resolve(schema: dict[str, Any], root: dict[str, Any]) -> list[dict[str, Any]]:
+    ref = schema.get("$ref")
+    if isinstance(ref, str) and ref.startswith("#/$defs/"):
+        target = root.get("$defs", {}).get(ref.split("/")[-1])
+        return _resolve(target, root) if isinstance(target, dict) else []
+
+    variants = schema.get("anyOf") or schema.get("oneOf")
+    if isinstance(variants, list):
+        return [
+            resolved
+            for variant in variants
+            if isinstance(variant, dict)
+            for resolved in _resolve(variant, root)
+        ]
+
+    return [schema]
+
+
+def undefined_input_fields(
+    schema: dict[str, Any] | None,
+    value: Any,
+    root: dict[str, Any] | None = None,
+    prefix: str = "",
+    depth: int = 0,
+) -> list[str]:
+    """Paths in ``value`` that ``schema`` does not define.
+
+    The app API answers 500 rather than a validation error when it is given a
+    field the template does not have, which is what a config written for
+    another version of the same app usually carries.
+    """
+    if not isinstance(schema, dict) or not isinstance(value, dict) or depth > 10:
+        return []
+
+    root = root if root is not None else schema
+    variants = _resolve(schema, root)
+
+    known: dict[str, dict[str, Any]] = {}
+    for variant in variants:
+        properties = variant.get("properties")
+        if isinstance(properties, dict):
+            for name, definition in properties.items():
+                if isinstance(definition, dict):
+                    known.setdefault(name, definition)
+
+    if not known:
+        return []
+
+    undefined = []
+    for name, nested in value.items():
+        path = f"{prefix}.{name}" if prefix else name
+        definition = known.get(name)
+        if definition is None:
+            undefined.append(path)
+        else:
+            undefined.extend(
+                undefined_input_fields(definition, nested, root, path, depth + 1)
+            )
+
+    return undefined
 
 
 @rewrite_module
@@ -224,12 +287,24 @@ class Apps(metaclass=NoPublicConstructor):
             item = await resp.json()
             return self._parse_app_read_instance(item)
 
-    def _can_configure_app(self, existing_app: App, app_data: dict[str, Any]) -> bool:
-        if existing_app.template_name != app_data["template_name"]:
-            return False
-        elif existing_app.template_version != app_data["template_version"]:
-            return False
-        return True
+    async def _undefined_for_app(
+        self, existing_app: App, app_data: dict[str, Any]
+    ) -> builtins.list[str]:
+        try:
+            template = await self.get_template(
+                name=existing_app.template_name,
+                version=existing_app.template_version,
+                cluster_name=existing_app.cluster_name,
+                org_name=existing_app.org_name,
+                project_name=existing_app.project_name,
+            )
+        except ResourceNotFound:
+            return []
+
+        if template is None:
+            return []
+
+        return undefined_input_fields(template.input, app_data.get("input"))
 
     async def configure(
         self,
@@ -238,8 +313,25 @@ class Apps(metaclass=NoPublicConstructor):
         comment: str | None = None,
     ) -> App:
         existing_app = await self.get(app_id)
-        if not self._can_configure_app(existing_app, app_data):
-            raise ValueError("Cannot update app: template name or version mismatch")
+
+        if existing_app.template_name != app_data.get("template_name"):
+            raise ValueError(
+                f"Cannot update app: it was installed from "
+                f"{existing_app.template_name!r} and the config is for "
+                f"{app_data.get('template_name')!r}"
+            )
+
+        undefined = await self._undefined_for_app(existing_app, app_data)
+
+        if undefined:
+            raise ValueError(
+                f"Cannot update app: "
+                f"{existing_app.template_version} has no "
+                f"{', '.join(undefined)}. Remove "
+                f"{'them' if len(undefined) > 1 else 'it'} from the config or "
+                f"install a version that still has "
+                f"{'them' if len(undefined) > 1 else 'it'}."
+            )
 
         url = (
             self._build_base_url(

--- a/apolo-sdk/src/apolo_sdk/_apps.py
+++ b/apolo-sdk/src/apolo_sdk/_apps.py
@@ -1,5 +1,6 @@
 import builtins
 import enum
+import logging
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -12,6 +13,8 @@ from ._config import Config
 from ._core import _Core
 from ._rewrite import rewrite_module
 from ._utils import NoPublicConstructor, asyncgeneratorcontextmanager
+
+log = logging.getLogger(__package__)
 
 
 @rewrite_module
@@ -99,53 +102,80 @@ class AppConfigurationRevision:
     end_at: datetime | None
 
 
-def _resolve(schema: Any, root: dict[str, Any]) -> list[dict[str, Any]]:
+APP_INSTANCE_REF = "app-instance-ref"
+_MAX_DEPTH = 16
+
+
+def _resolve(
+    schema: Any, root: dict[str, Any], seen: frozenset[str] = frozenset()
+) -> list[dict[str, Any]]:
+    """Every shape a value at this position is allowed to take."""
     if not isinstance(schema, dict):
         return []
 
     ref = schema.get("$ref")
-    if isinstance(ref, str) and ref.startswith("#/$defs/"):
-        return _resolve(root.get("$defs", {}).get(ref.split("/")[-1]), root)
+    if isinstance(ref, str):
+        if not ref.startswith("#/") or ref in seen:
+            return []
+        target: Any = root
+        for part in ref[2:].split("/"):
+            target = target.get(part, {}) if isinstance(target, dict) else {}
+        return _resolve(target, root, seen | {ref})
 
-    variants = schema.get("anyOf") or schema.get("oneOf")
-    if isinstance(variants, list):
-        return [
-            resolved for variant in variants for resolved in _resolve(variant, root)
-        ]
+    for keyword in ("anyOf", "oneOf", "allOf"):
+        variants = schema.get(keyword)
+        if isinstance(variants, list):
+            return [
+                resolved
+                for variant in variants
+                for resolved in _resolve(variant, root, seen)
+            ]
 
     return [schema]
 
 
-def undefined_input_fields(
+def _sortable(path: str) -> tuple[Any, ...]:
+    return tuple(
+        (1, int(part)) if part.isdigit() else (0, part) for part in path.split(".")
+    )
+
+
+def _undefined_input_fields(
     schema: Any,
     value: Any,
     root: dict[str, Any] | None = None,
     prefix: str = "",
     depth: int = 0,
 ) -> list[str]:
-    """Paths in ``value`` that ``schema`` does not define.
-
-    The app API answers 500 rather than a validation error when it is given a
-    field the template does not have, which is what a config written for
-    another version of the same app usually carries.
-    """
-    if depth > 16:
+    if depth > _MAX_DEPTH:
         return []
 
     root = root if root is not None else (schema if isinstance(schema, dict) else {})
     variants = _resolve(schema, root)
 
     if isinstance(value, list):
-        return [
-            path
-            for index, item in enumerate(value)
-            for variant in variants[:1]
-            for path in undefined_input_fields(
-                variant.get("items"), item, root, f"{prefix}.{index}", depth + 1
-            )
+        per_variant = [
+            [
+                path
+                for index, item in enumerate(value)
+                for path in _undefined_input_fields(
+                    variant.get("items"),
+                    item,
+                    root,
+                    f"{prefix}.{index}" if prefix else str(index),
+                    depth + 1,
+                )
+            ]
+            for variant in variants
+            if isinstance(variant.get("items"), dict)
         ]
+        return _common(per_variant)
 
     if not isinstance(value, dict):
+        return []
+
+    # a value taken from another app stands in for whatever the field holds
+    if value.get("type") == APP_INSTANCE_REF:
         return []
 
     known: dict[str, list[Any]] = {}
@@ -171,14 +201,24 @@ def undefined_input_fields(
                 undefined.append(path)
             continue
 
-        # a key is only undefined when every variant that could hold it says so
-        per_variant = [
-            undefined_input_fields(definition, nested, root, path, depth + 1)
-            for definition in definitions
-        ]
-        undefined.extend(set.intersection(*(set(paths) for paths in per_variant)))
+        undefined.extend(
+            _common(
+                [
+                    _undefined_input_fields(definition, nested, root, path, depth + 1)
+                    for definition in definitions
+                ]
+            )
+        )
 
-    return sorted(undefined)
+    return sorted(undefined, key=_sortable)
+
+
+def _common(per_variant: list[list[str]]) -> list[str]:
+    """What every shape the value is allowed to take agrees is undefined."""
+    if not per_variant:
+        return []
+
+    return list(set.intersection(*(set(paths) for paths in per_variant)))
 
 
 @rewrite_module
@@ -309,6 +349,10 @@ class Apps(metaclass=NoPublicConstructor):
     async def _undefined_for_app(
         self, existing_app: App, app_data: dict[str, Any]
     ) -> builtins.list[str]:
+        if existing_app.template_version == app_data.get("template_version"):
+            # the config was written for the version the app runs
+            return []
+
         try:
             template = await self.get_template(
                 name=existing_app.template_name,
@@ -317,15 +361,15 @@ class Apps(metaclass=NoPublicConstructor):
                 org_name=existing_app.org_name,
                 project_name=existing_app.project_name,
             )
-        except Exception:
+            if template is None:
+                return []
+
+            return _undefined_input_fields(template.input, app_data.get("input"))
+        except Exception as error:
             # the check is a courtesy, and must never stand between the user
             # and a call the server would have accepted
+            log.debug("Could not check the config against the schema: %s", error)
             return []
-
-        if template is None:
-            return []
-
-        return undefined_input_fields(template.input, app_data.get("input"))
 
     async def configure(
         self,
@@ -335,23 +379,29 @@ class Apps(metaclass=NoPublicConstructor):
     ) -> App:
         existing_app = await self.get(app_id)
 
-        if existing_app.template_name != app_data.get("template_name"):
+        config_template = app_data.get("template_name")
+        if (
+            config_template is not None
+            and config_template != existing_app.template_name
+        ):
             raise ValueError(
                 f"Cannot update app: it was installed from "
                 f"{existing_app.template_name!r} and the config is for "
-                f"{app_data.get('template_name')!r}"
+                f"{config_template!r}"
             )
 
         undefined = await self._undefined_for_app(existing_app, app_data)
 
         if undefined:
+            shown = ", ".join(undefined[:10])
+            if len(undefined) > 10:
+                shown += f" and {len(undefined) - 10} more"
+            them = "them" if len(undefined) > 1 else "it"
             raise ValueError(
-                f"Cannot update app: "
-                f"{existing_app.template_version} has no "
-                f"{', '.join(undefined)}. Remove "
-                f"{'them' if len(undefined) > 1 else 'it'} from the config or "
-                f"install a version that still has "
-                f"{'them' if len(undefined) > 1 else 'it'}."
+                f"Cannot update app: {existing_app.template_name} "
+                f"{existing_app.template_version} has no {shown}. "
+                f"Remove {them} from the config, or reinstall the app on a "
+                f"version that has {them}."
             )
 
         url = (

--- a/apolo-sdk/src/apolo_sdk/_apps.py
+++ b/apolo-sdk/src/apolo_sdk/_apps.py
@@ -10,7 +10,6 @@ from yarl import URL
 
 from ._config import Config
 from ._core import _Core
-from ._errors import ResourceNotFound
 from ._rewrite import rewrite_module
 from ._utils import NoPublicConstructor, asyncgeneratorcontextmanager
 
@@ -100,26 +99,25 @@ class AppConfigurationRevision:
     end_at: datetime | None
 
 
-def _resolve(schema: dict[str, Any], root: dict[str, Any]) -> list[dict[str, Any]]:
+def _resolve(schema: Any, root: dict[str, Any]) -> list[dict[str, Any]]:
+    if not isinstance(schema, dict):
+        return []
+
     ref = schema.get("$ref")
     if isinstance(ref, str) and ref.startswith("#/$defs/"):
-        target = root.get("$defs", {}).get(ref.split("/")[-1])
-        return _resolve(target, root) if isinstance(target, dict) else []
+        return _resolve(root.get("$defs", {}).get(ref.split("/")[-1]), root)
 
     variants = schema.get("anyOf") or schema.get("oneOf")
     if isinstance(variants, list):
         return [
-            resolved
-            for variant in variants
-            if isinstance(variant, dict)
-            for resolved in _resolve(variant, root)
+            resolved for variant in variants for resolved in _resolve(variant, root)
         ]
 
     return [schema]
 
 
 def undefined_input_fields(
-    schema: dict[str, Any] | None,
+    schema: Any,
     value: Any,
     root: dict[str, Any] | None = None,
     prefix: str = "",
@@ -131,19 +129,34 @@ def undefined_input_fields(
     field the template does not have, which is what a config written for
     another version of the same app usually carries.
     """
-    if not isinstance(schema, dict) or not isinstance(value, dict) or depth > 10:
+    if depth > 16:
         return []
 
-    root = root if root is not None else schema
+    root = root if root is not None else (schema if isinstance(schema, dict) else {})
     variants = _resolve(schema, root)
 
-    known: dict[str, dict[str, Any]] = {}
+    if isinstance(value, list):
+        return [
+            path
+            for index, item in enumerate(value)
+            for variant in variants[:1]
+            for path in undefined_input_fields(
+                variant.get("items"), item, root, f"{prefix}.{index}", depth + 1
+            )
+        ]
+
+    if not isinstance(value, dict):
+        return []
+
+    known: dict[str, list[Any]] = {}
+    accepts_anything = False
     for variant in variants:
+        if variant.get("additionalProperties") not in (None, False):
+            accepts_anything = True
         properties = variant.get("properties")
         if isinstance(properties, dict):
             for name, definition in properties.items():
-                if isinstance(definition, dict):
-                    known.setdefault(name, definition)
+                known.setdefault(name, []).append(definition)
 
     if not known:
         return []
@@ -151,15 +164,21 @@ def undefined_input_fields(
     undefined = []
     for name, nested in value.items():
         path = f"{prefix}.{name}" if prefix else name
-        definition = known.get(name)
-        if definition is None:
-            undefined.append(path)
-        else:
-            undefined.extend(
-                undefined_input_fields(definition, nested, root, path, depth + 1)
-            )
+        definitions = known.get(name)
 
-    return undefined
+        if not definitions:
+            if not accepts_anything:
+                undefined.append(path)
+            continue
+
+        # a key is only undefined when every variant that could hold it says so
+        per_variant = [
+            undefined_input_fields(definition, nested, root, path, depth + 1)
+            for definition in definitions
+        ]
+        undefined.extend(set.intersection(*(set(paths) for paths in per_variant)))
+
+    return sorted(undefined)
 
 
 @rewrite_module
@@ -298,7 +317,9 @@ class Apps(metaclass=NoPublicConstructor):
                 org_name=existing_app.org_name,
                 project_name=existing_app.project_name,
             )
-        except ResourceNotFound:
+        except Exception:
+            # the check is a courtesy, and must never stand between the user
+            # and a call the server would have accepted
             return []
 
         if template is None:

--- a/apolo-sdk/src/apolo_sdk/_apps.py
+++ b/apolo-sdk/src/apolo_sdk/_apps.py
@@ -109,7 +109,6 @@ _MAX_DEPTH = 16
 def _resolve(
     schema: Any, root: dict[str, Any], seen: frozenset[str] = frozenset()
 ) -> list[dict[str, Any]]:
-    """Every shape a value at this position is allowed to take."""
     if not isinstance(schema, dict):
         return []
 
@@ -174,7 +173,6 @@ def _undefined_input_fields(
     if not isinstance(value, dict):
         return []
 
-    # a value taken from another app stands in for whatever the field holds
     if value.get("type") == APP_INSTANCE_REF:
         return []
 
@@ -214,7 +212,6 @@ def _undefined_input_fields(
 
 
 def _common(per_variant: list[list[str]]) -> list[str]:
-    """What every shape the value is allowed to take agrees is undefined."""
     if not per_variant:
         return []
 
@@ -350,7 +347,6 @@ class Apps(metaclass=NoPublicConstructor):
         self, existing_app: App, app_data: dict[str, Any]
     ) -> builtins.list[str]:
         if existing_app.template_version == app_data.get("template_version"):
-            # the config was written for the version the app runs
             return []
 
         try:
@@ -366,8 +362,6 @@ class Apps(metaclass=NoPublicConstructor):
 
             return _undefined_input_fields(template.input, app_data.get("input"))
         except Exception as error:
-            # the check is a courtesy, and must never stand between the user
-            # and a call the server would have accepted
             log.debug("Could not check the config against the schema: %s", error)
             return []
 

--- a/apolo-sdk/tests/test_apps.py
+++ b/apolo-sdk/tests/test_apps.py
@@ -15,7 +15,7 @@ from apolo_sdk import (
     AppState,
     Client,
 )
-from apolo_sdk._apps import undefined_input_fields
+from apolo_sdk._apps import _undefined_input_fields as undefined_input_fields
 
 from tests import _TestServerFactory
 
@@ -1688,6 +1688,40 @@ def test_undefined_input_fields() -> None:
     assert undefined_input_fields(None, {"anything": 1}) == []
 
 
+def test_undefined_input_fields_leaves_a_value_from_another_app_alone() -> None:
+    """`apolo app-template get-config` tells users to write exactly this."""
+    schema = {
+        "properties": {"s3": {"$ref": "#/$defs/S3"}},
+        "$defs": {"S3": {"properties": {"port": {"type": "integer"}}}},
+    }
+    reference = {"type": "app-instance-ref", "instance_id": "i", "path": "p"}
+
+    assert undefined_input_fields(schema, {"s3": reference}) == []
+
+
+def test_undefined_input_fields_reads_through_allof_and_plain_pointers() -> None:
+    wrapped = {
+        "properties": {"s3": {"allOf": [{"$ref": "#/$defs/S3"}], "description": "d"}},
+        "$defs": {"S3": {"properties": {"port": {"type": "integer"}}}},
+    }
+    assert undefined_input_fields(wrapped, {"s3": {"port": 1, "old": 2}}) == ["s3.old"]
+
+    draft07 = {
+        "properties": {"s3": {"$ref": "#/definitions/S3"}},
+        "definitions": {"S3": {"properties": {"port": {"type": "integer"}}}},
+    }
+    assert undefined_input_fields(draft07, {"s3": {"port": 1, "old": 2}}) == ["s3.old"]
+
+
+def test_undefined_input_fields_survives_a_schema_that_points_at_itself() -> None:
+    cyclic = {
+        "properties": {"node": {"$ref": "#/$defs/Node"}},
+        "$defs": {"Node": {"anyOf": [{"$ref": "#/$defs/Node"}]}},
+    }
+
+    assert undefined_input_fields(cyclic, {"node": {"anything": 1}}) == []
+
+
 def test_undefined_input_fields_descends_into_arrays() -> None:
     schema = {
         "properties": {
@@ -1720,6 +1754,39 @@ def test_undefined_input_fields_accepts_a_key_from_any_variant() -> None:
     assert undefined_input_fields(schema, {"auth": {"username": "u"}}) == []
     assert undefined_input_fields(schema, {"auth": {"token": "t"}}) == []
     assert undefined_input_fields(schema, {"auth": {"neither": 1}}) == ["auth.neither"]
+
+
+def test_undefined_input_fields_reads_an_array_against_every_variant() -> None:
+    schema = {
+        "properties": {
+            "ports": {
+                "anyOf": [
+                    {"type": "null"},
+                    {"type": "array", "items": {"$ref": "#/$defs/P"}},
+                ]
+            }
+        },
+        "$defs": {"P": {"properties": {"port": {"type": "integer"}}}},
+    }
+
+    # the null variant comes first, and must not stop the items being read
+    assert undefined_input_fields(schema, {"ports": [{"port": 1}]}) == []
+    assert undefined_input_fields(schema, {"ports": [{"old": 1}]}) == ["ports.0.old"]
+
+
+def test_undefined_input_fields_orders_array_paths_by_index() -> None:
+    schema = {
+        "properties": {
+            "ports": {"type": "array", "items": {"properties": {"port": {}}}}
+        },
+    }
+    value = {"ports": [{"old": 1} for _ in range(12)]}
+
+    assert undefined_input_fields(schema, value)[:3] == [
+        "ports.0.old",
+        "ports.1.old",
+        "ports.2.old",
+    ]
 
 
 def test_undefined_input_fields_leaves_open_schemas_alone() -> None:

--- a/apolo-sdk/tests/test_apps.py
+++ b/apolo-sdk/tests/test_apps.py
@@ -1613,6 +1613,58 @@ async def test_apps_configure_names_fields_the_version_does_not_have(
             )
 
 
+async def test_apps_configure_when_the_template_cannot_be_read(
+    aiohttp_server: _TestServerFactory,
+    make_client: Callable[..., Client],
+) -> None:
+    """The check is a courtesy: losing it must not cost the user the call."""
+    instance = {
+        "id": "someid",
+        "name": "name",
+        "display_name": "display_name",
+        "template_name": "aws-s3",
+        "template_version": "26.0.1",
+        "project_name": "test3",
+        "org_name": "superorg",
+        "cluster_name": "default",
+        "namespace": "namespace",
+        "state": "state",
+        "creator": "creator",
+        "created_at": "2025-05-07 11:00:00+00:00",
+        "updated_at": "2025-05-07 11:00:00+00:00",
+        "endpoints": [],
+    }
+    sent = {}
+
+    async def handler(request: web.Request) -> web.Response:
+        if "templates" in request.path:
+            return web.json_response(data={"error": "nope"}, status=500)
+        if request.method == "PUT":
+            sent.update(await request.json())
+        return web.json_response(data=instance, status=200)
+
+    web_app = web.Application()
+    web_app.router.add_get("/apis/apps/v2/instances/someid", handler)
+    web_app.router.add_get(
+        "/apis/apps/v1/cluster/default/org/superorg/project/test3"
+        "/templates/aws-s3/26.0.1",
+        handler,
+    )
+    web_app.router.add_put(
+        "/apis/apps/v1/cluster/default/org/superorg/project/test3/instances/someid",
+        handler,
+    )
+    srv = await aiohttp_server(web_app)
+
+    async with make_client(srv.make_url("/")) as client:
+        await client.apps.configure(
+            app_id="someid",
+            app_data={"template_name": "aws-s3", "input": {"s3": {"port": 1}}},
+        )
+
+    assert sent == {"input": {"s3": {"port": 1}}}
+
+
 def test_undefined_input_fields() -> None:
     schema = {
         "properties": {
@@ -1634,3 +1686,47 @@ def test_undefined_input_fields() -> None:
     # nothing to say about a schema that declares no properties
     assert undefined_input_fields({}, {"anything": 1}) == []
     assert undefined_input_fields(None, {"anything": 1}) == []
+
+
+def test_undefined_input_fields_descends_into_arrays() -> None:
+    schema = {
+        "properties": {
+            "ports": {
+                "type": "array",
+                "items": {"$ref": "#/$defs/Port"},
+            }
+        },
+        "$defs": {"Port": {"properties": {"port": {"type": "integer"}}}},
+    }
+
+    assert undefined_input_fields(schema, {"ports": [{"port": 80}]}) == []
+    assert undefined_input_fields(schema, {"ports": [{"port": 80}, {"old": 1}]}) == [
+        "ports.1.old"
+    ]
+
+
+def test_undefined_input_fields_accepts_a_key_from_any_variant() -> None:
+    """A property several variants define must be read against all of them."""
+    schema = {
+        "properties": {
+            "auth": {"anyOf": [{"$ref": "#/$defs/A"}, {"$ref": "#/$defs/B"}]}
+        },
+        "$defs": {
+            "A": {"properties": {"username": {"type": "string"}}},
+            "B": {"properties": {"token": {"type": "string"}}},
+        },
+    }
+
+    assert undefined_input_fields(schema, {"auth": {"username": "u"}}) == []
+    assert undefined_input_fields(schema, {"auth": {"token": "t"}}) == []
+    assert undefined_input_fields(schema, {"auth": {"neither": 1}}) == ["auth.neither"]
+
+
+def test_undefined_input_fields_leaves_open_schemas_alone() -> None:
+    schema = {
+        "properties": {
+            "labels": {"type": "object", "additionalProperties": {"type": "string"}}
+        }
+    }
+
+    assert undefined_input_fields(schema, {"labels": {"anything": "x"}}) == []

--- a/apolo-sdk/tests/test_apps.py
+++ b/apolo-sdk/tests/test_apps.py
@@ -15,6 +15,7 @@ from apolo_sdk import (
     AppState,
     Client,
 )
+from apolo_sdk._apps import undefined_input_fields
 
 from tests import _TestServerFactory
 
@@ -1449,3 +1450,187 @@ async def test_apps_list_with_states_filter(
                 apps.append(app)
 
         assert len(apps) == 2
+
+
+async def test_apps_configure_across_versions(
+    aiohttp_server: _TestServerFactory,
+    make_client: Callable[..., Client],
+) -> None:
+    """A config written for another version of the same app still applies."""
+    instance = {
+        "id": "someid",
+        "name": "name",
+        "display_name": "display_name",
+        "template_name": "aws-s3",
+        "template_version": "26.0.1",
+        "project_name": "test3",
+        "org_name": "superorg",
+        "cluster_name": "default",
+        "namespace": "namespace",
+        "state": "state",
+        "creator": "creator",
+        "created_at": "2025-05-07 11:00:00+00:00",
+        "updated_at": "2025-05-07 11:00:00+00:00",
+        "endpoints": [],
+    }
+    template = {
+        "name": "aws-s3",
+        "version": "26.0.1",
+        "input": {
+            "properties": {"s3": {"$ref": "#/$defs/S3Params"}},
+            "$defs": {
+                "S3Params": {"properties": {"port": {"type": "integer"}}},
+            },
+        },
+    }
+    sent = {}
+
+    async def handler(request: web.Request) -> web.Response:
+        if request.method == "GET":
+            if "templates" in request.path:
+                return web.json_response(data=template, status=200)
+            return web.json_response(data=instance, status=200)
+        sent.update(await request.json())
+        return web.json_response(data=instance, status=200)
+
+    web_app = web.Application()
+    web_app.router.add_get("/apis/apps/v2/instances/someid", handler)
+    web_app.router.add_get(
+        "/apis/apps/v1/cluster/default/org/superorg/project/test3"
+        "/templates/aws-s3/26.0.1",
+        handler,
+    )
+    web_app.router.add_put(
+        "/apis/apps/v1/cluster/default/org/superorg/project/test3/instances/someid",
+        handler,
+    )
+    srv = await aiohttp_server(web_app)
+
+    async with make_client(srv.make_url("/")) as client:
+        await client.apps.configure(
+            app_id="someid",
+            app_data={
+                "template_name": "aws-s3",
+                "template_version": "26.0.0",
+                "input": {"s3": {"port": 8080}},
+            },
+        )
+
+    assert sent == {"input": {"s3": {"port": 8080}}}
+
+
+async def test_apps_configure_rejects_another_app(
+    aiohttp_server: _TestServerFactory,
+    make_client: Callable[..., Client],
+) -> None:
+    instance = {
+        "id": "someid",
+        "name": "name",
+        "display_name": "display_name",
+        "template_name": "aws-s3",
+        "template_version": "26.0.1",
+        "project_name": "test3",
+        "org_name": "superorg",
+        "cluster_name": "default",
+        "namespace": "namespace",
+        "state": "state",
+        "creator": "creator",
+        "created_at": "2025-05-07 11:00:00+00:00",
+        "updated_at": "2025-05-07 11:00:00+00:00",
+        "endpoints": [],
+    }
+
+    async def handler(request: web.Request) -> web.Response:
+        return web.json_response(data=instance, status=200)
+
+    web_app = web.Application()
+    web_app.router.add_get("/apis/apps/v2/instances/someid", handler)
+    srv = await aiohttp_server(web_app)
+
+    async with make_client(srv.make_url("/")) as client:
+        with pytest.raises(ValueError, match="installed from 'aws-s3'"):
+            await client.apps.configure(
+                app_id="someid",
+                app_data={"template_name": "shell", "input": {}},
+            )
+
+
+async def test_apps_configure_names_fields_the_version_does_not_have(
+    aiohttp_server: _TestServerFactory,
+    make_client: Callable[..., Client],
+) -> None:
+    """The API answers 500 for those, so they are caught before it is called."""
+    instance = {
+        "id": "someid",
+        "name": "name",
+        "display_name": "display_name",
+        "template_name": "aws-s3",
+        "template_version": "26.0.1",
+        "project_name": "test3",
+        "org_name": "superorg",
+        "cluster_name": "default",
+        "namespace": "namespace",
+        "state": "state",
+        "creator": "creator",
+        "created_at": "2025-05-07 11:00:00+00:00",
+        "updated_at": "2025-05-07 11:00:00+00:00",
+        "endpoints": [],
+    }
+    template = {
+        "name": "aws-s3",
+        "version": "26.0.1",
+        "input": {
+            "properties": {"s3": {"$ref": "#/$defs/S3Params"}},
+            "$defs": {
+                "S3Params": {"properties": {"port": {"type": "integer"}}},
+            },
+        },
+    }
+
+    async def handler(request: web.Request) -> web.Response:
+        if "templates" in request.path:
+            return web.json_response(data=template, status=200)
+        return web.json_response(data=instance, status=200)
+
+    web_app = web.Application()
+    web_app.router.add_get("/apis/apps/v2/instances/someid", handler)
+    web_app.router.add_get(
+        "/apis/apps/v1/cluster/default/org/superorg/project/test3"
+        "/templates/aws-s3/26.0.1",
+        handler,
+    )
+    srv = await aiohttp_server(web_app)
+
+    async with make_client(srv.make_url("/")) as client:
+        with pytest.raises(ValueError, match="s3.dockerconfigjson"):
+            await client.apps.configure(
+                app_id="someid",
+                app_data={
+                    "template_name": "aws-s3",
+                    "template_version": "26.0.0",
+                    "input": {"s3": {"port": 8080, "dockerconfigjson": {"f": "x"}}},
+                },
+            )
+
+
+def test_undefined_input_fields() -> None:
+    schema = {
+        "properties": {
+            "image": {"$ref": "#/$defs/Image"},
+            "auth": {"anyOf": [{"$ref": "#/$defs/Basic"}, {"type": "null"}]},
+        },
+        "$defs": {
+            "Image": {"properties": {"repository": {"type": "string"}}},
+            "Basic": {"properties": {"username": {"type": "string"}}},
+        },
+    }
+
+    assert undefined_input_fields(schema, {"image": {"repository": "r"}}) == []
+    assert undefined_input_fields(schema, {"image": {"old": 1}}) == ["image.old"]
+    assert undefined_input_fields(schema, {"gone": 1}) == ["gone"]
+    # a variant of a union counts as defined
+    assert undefined_input_fields(schema, {"auth": {"username": "u"}}) == []
+    assert undefined_input_fields(schema, {"auth": {"token": "t"}}) == ["auth.token"]
+    # nothing to say about a schema that declares no properties
+    assert undefined_input_fields({}, {"anything": 1}) == []
+    assert undefined_input_fields(None, {"anything": 1}) == []

--- a/apolo-sdk/tests/test_apps.py
+++ b/apolo-sdk/tests/test_apps.py
@@ -1456,7 +1456,6 @@ async def test_apps_configure_across_versions(
     aiohttp_server: _TestServerFactory,
     make_client: Callable[..., Client],
 ) -> None:
-    """A config written for another version of the same app still applies."""
     instance = {
         "id": "someid",
         "name": "name",
@@ -1559,7 +1558,6 @@ async def test_apps_configure_names_fields_the_version_does_not_have(
     aiohttp_server: _TestServerFactory,
     make_client: Callable[..., Client],
 ) -> None:
-    """The API answers 500 for those, so they are caught before it is called."""
     instance = {
         "id": "someid",
         "name": "name",
@@ -1617,7 +1615,6 @@ async def test_apps_configure_when_the_template_cannot_be_read(
     aiohttp_server: _TestServerFactory,
     make_client: Callable[..., Client],
 ) -> None:
-    """The check is a courtesy: losing it must not cost the user the call."""
     instance = {
         "id": "someid",
         "name": "name",
@@ -1680,16 +1677,13 @@ def test_undefined_input_fields() -> None:
     assert undefined_input_fields(schema, {"image": {"repository": "r"}}) == []
     assert undefined_input_fields(schema, {"image": {"old": 1}}) == ["image.old"]
     assert undefined_input_fields(schema, {"gone": 1}) == ["gone"]
-    # a variant of a union counts as defined
     assert undefined_input_fields(schema, {"auth": {"username": "u"}}) == []
     assert undefined_input_fields(schema, {"auth": {"token": "t"}}) == ["auth.token"]
-    # nothing to say about a schema that declares no properties
     assert undefined_input_fields({}, {"anything": 1}) == []
     assert undefined_input_fields(None, {"anything": 1}) == []
 
 
 def test_undefined_input_fields_leaves_a_value_from_another_app_alone() -> None:
-    """`apolo app-template get-config` tells users to write exactly this."""
     schema = {
         "properties": {"s3": {"$ref": "#/$defs/S3"}},
         "$defs": {"S3": {"properties": {"port": {"type": "integer"}}}},
@@ -1740,7 +1734,6 @@ def test_undefined_input_fields_descends_into_arrays() -> None:
 
 
 def test_undefined_input_fields_accepts_a_key_from_any_variant() -> None:
-    """A property several variants define must be read against all of them."""
     schema = {
         "properties": {
             "auth": {"anyOf": [{"$ref": "#/$defs/A"}, {"$ref": "#/$defs/B"}]}
@@ -1769,7 +1762,6 @@ def test_undefined_input_fields_reads_an_array_against_every_variant() -> None:
         "$defs": {"P": {"properties": {"port": {"type": "integer"}}}},
     }
 
-    # the null variant comes first, and must not stop the items being read
     assert undefined_input_fields(schema, {"ports": [{"port": 1}]}) == []
     assert undefined_input_fields(schema, {"ports": [{"old": 1}]}) == ["ports.0.old"]
 


### PR DESCRIPTION
Closes [APS-412](https://apolocloud.atlassian.net/browse/APS-412), the CLI half of [APS-405](https://apolocloud.atlassian.net/browse/APS-405).

## Problem

`apolo app configure` refused any file whose `template_version` differed from the installed app's:

```
$ apolo app configure <id> -f config.yaml
ERROR: Cannot update app: template name or version mismatch
```

The version in the file was never used for anything — `configure` sends only `display_name` and `input`, and the app stays on the version it was installed with. The console dropped the same comparison in APS-405 (#605), where measuring the catalogue showed 58% of consecutive version pairs ship a byte-identical schema and 35 of 36 templates publish moving refs like `master`, so the string tells you nothing.

## Change

The version comparison is gone. The template **name** is still checked, and says what it found:

```
ERROR: Cannot update app: it was installed from 'aws-s3' and the config is for 'shell'
```

## The part that is not just deleting a check

The app API answers **500 Internal Server Error** — not a validation error — when the input carries a field the template does not define:

```
PUT .../instances/<id>   valid input                          -> 200
PUT .../instances/<id>   same input + one undefined field     -> 500   (twice, deterministic)
POST .../instances       same input + one undefined field     -> 500
```

That is exactly what a config written for an older version usually carries: a field the newer version renamed or dropped. In the console's replay of the catalogue, about one cross-version config in four carries such a field, and `apolo app install -f` can hit this today — there is no version gate on install.

So dropping the gate alone would have swapped one bad experience for a worse one. `configure` now fetches the schema of the version the app runs and names those fields itself:

```
ERROR: Cannot update app: 26.0.0 has no s3.dockerconfigjson, gone_in_this_version.
Remove them from the config or install a version that still has them.
```

The check only reports fields the schema has no place for — everything else stays the server's business, and a template that cannot be fetched skips the check entirely rather than blocking the call.

I will raise the 500 separately against the app API; this is a client-side guard, not the fix.

## Verified on dev

Against a throwaway `aws-s3` instance installed on `26.0.0` (uninstalled afterwards):

| | before | after |
|---|---|---|
| config for `26.0.1`, app on `26.0.0` (identical schemas) | `template name or version mismatch` | **applies** |
| config for another app | same generic message | names both templates |
| config carrying `s3.dockerconfigjson` | would have been a 500 | names the field |

Read back with `apolo app get-input` after the cross-version configure:

```yaml
s3:
  bucket: aws412-reconfigured   # from the 26.0.1 file
  port: 9090
```

## Tests

Three cases against the fake server — cross-version configure sends `{display_name, input}` and nothing else, a config for another app is refused, a config with an undefined field is refused naming it — plus a unit test for the schema walk covering `$ref`/`$defs`, `anyOf` variants, nested paths, and schemas that declare no properties.

`pytest apolo-sdk` 767 passed, `mypy apolo-sdk` clean, black/isort/flake8 clean.


[APS-412]: https://apolocloud.atlassian.net/browse/APS-412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APS-405]: https://apolocloud.atlassian.net/browse/APS-405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ